### PR TITLE
Fix share button design on post page

### DIFF
--- a/ckanorg/static/css/main.css
+++ b/ckanorg/static/css/main.css
@@ -3366,9 +3366,7 @@ ul.blog-nav li.last {
             backface-visibility: hidden;
     z-index: 2;
     transform: rotateX(0deg);
-    background-image: url("http://frolovoleg.ru/images/share.svg");
     background-repeat: no-repeat;
-    background-position: 72px center;
     color: #212c3f;
 }
 .share-container .back {


### PR DESCRIPTION
Before:
![Screenshot 2022-12-07 at 11-28-03 Towards a Robust Open-Source Civic Data Ecosystem](https://user-images.githubusercontent.com/200230/206156968-0ab0650f-5d46-40d6-bdf6-bd9574071357.png)

After:
![Screenshot 2022-12-07 at 11-35-37 Towards a Robust Open-Source Civic Data Ecosystem](https://user-images.githubusercontent.com/200230/206156987-40a04bed-4a22-4089-bd4a-dd5a19c4894b.png)

It was hotlinking to an SVG in a Russian website

I made the changes directly to the main.css file because I could not find the items on the SCSS ones, but let me know if that's not correct

