### PR TITLE
feat(stories): reader enhancements — share button, YouTube embed, slug URLs

### DIFF
--- a/ckanorg/static/css/main.css
+++ b/ckanorg/static/css/main.css
@@ -5078,6 +5078,106 @@ body {
   cursor: default;
   pointer-events: none;
 }
+.stories-content .reader-footer-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.stories-content .share-wrap {
+  position: relative;
+}
+.stories-content .btn-share {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1.5px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  background: #fff;
+  font-family: inherit;
+  transition: border-color 0.15s, background 0.15s;
+  color: var(--text);
+}
+.stories-content .btn-share:hover {
+  border-color: #bbb;
+  background: var(--bg-soft);
+}
+.stories-content .share-btn-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  color: var(--muted);
+}
+.stories-content .share-dropdown {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(6px);
+  transition: opacity 0.15s, transform 0.15s;
+  position: absolute;
+  bottom: calc(100% + 8px);
+  right: 0;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.09);
+  border-radius: 12px;
+  padding: 5px;
+  min-width: 176px;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.11), 0 2px 6px rgba(0, 0, 0, 0.06);
+  z-index: 10;
+}
+.stories-content .share-dropdown.open {
+  opacity: 1;
+  pointer-events: all;
+  transform: translateY(0);
+}
+.stories-content .share-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 8px;
+}
+.stories-content .share-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  padding: 9px 11px;
+  font-size: 13px;
+  font-weight: 500;
+  border: none;
+  background: none;
+  cursor: pointer;
+  border-radius: 8px;
+  font-family: inherit;
+  text-decoration: none;
+  color: var(--text);
+  transition: background 0.12s;
+}
+.stories-content .share-option:hover {
+  background: var(--bg-soft);
+  text-decoration: none;
+  color: var(--text);
+}
+.stories-content .share-option-icon {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  color: var(--muted);
+}
+.stories-content .reader-video {
+  margin: 28px 0 0;
+  aspect-ratio: 16/9;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #000;
+}
+.stories-content .reader-video iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
 .stories-content {
   /* ══ SUBMIT SECTION ══ */
 }

--- a/ckanorg/static/js/stories.js
+++ b/ckanorg/static/js/stories.js
@@ -57,7 +57,7 @@ function renderGrid(filter) {
     var tagsHtml = renderTags(s.tags);
     var primaryImpactHtml = renderPrimaryImpact(s.impact);
     var challengeText = escapeHtml(richTextToParagraphText(s.challenge));
-    return '<a class="story-card" href="#" onclick="openReader(' + s.id + '); return false;">' +
+    return '<a class="story-card" href="#" onclick="openReader(\'' + s.slug + '\'); return false;">' +
       '<div class="card-header" style="background:' + s.color + ';">' +
         '<div class="card-header-bg">' + s.emoji + '</div>' +
         '<div class="card-region">' + s.region + '</div>' +
@@ -84,10 +84,15 @@ function filterBy(tag, btn) {
 
 var currentIdx = 0;
 
-function openReader(id) {
-  var s = STORIES.find(function(x){ return x.id === id; });
+function getStoryUrl(slug) {
+  return window.location.origin + window.location.pathname + '?story=' + slug;
+}
+
+function openReader(slug) {
+  var s = STORIES.find(function(x){ return x.slug === slug; });
   if (!s) return;
   currentIdx = STORIES.indexOf(s);
+  history.replaceState(null, '', '?story=' + slug);
   document.getElementById('rBand').style.background = s.color;
   var onDark = s.color === '#ed5248';
   document.getElementById('rOrg').style.color = onDark ? 'rgba(255,255,255,0.6)' : 'rgba(0,0,0,0.45)';
@@ -114,9 +119,22 @@ function openReader(id) {
     }).join('') + '</div>' : '') +
     (s.outcome ? s.outcome : '') +
     (s.quote ? '<div class="reader-quote">' + s.quote + '<cite>' + s.quoteAuthor + '</cite></div>' : '') +
-    (s.portal ? '<h3>Portal</h3>' + '<a href="' + portalUrl + '" target="_blank" class="reader-portal-link">&#x1F310; ' + portalLabel + ' &#x2197;</a>' : '');
+    (s.portal ? '<h3>Portal</h3>' + '<a href="' + portalUrl + '" target="_blank" class="reader-portal-link">&#x1F310; ' + portalLabel + ' &#x2197;</a>' : '') +
+    (s.youtubeUrl ? '<div class="reader-video"><iframe src="' + youtubeEmbedUrl(s.youtubeUrl) + '" title="Session recording" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>' : '');
   document.getElementById('rPrev').disabled = currentIdx === 0;
   document.getElementById('rNext').disabled = currentIdx === STORIES.length - 1;
+
+  var storyUrl = getStoryUrl(s.slug);
+  var shareText = s.org + ' — ' + s.title + ' | CKAN Success Stories';
+  document.getElementById('shareLinkedIn').href =
+    'https://www.linkedin.com/sharing/share-offsite/?url=' + encodeURIComponent(storyUrl);
+  document.getElementById('shareX').href =
+    'https://x.com/intent/tweet?url=' + encodeURIComponent(storyUrl) + '&text=' + encodeURIComponent(shareText);
+  document.getElementById('shareBluesky').href =
+    'https://bsky.app/intent/compose?text=' + encodeURIComponent(shareText + ' ' + storyUrl);
+  document.getElementById('shareEmail').href =
+    'mailto:?subject=' + encodeURIComponent(shareText) + '&body=' + encodeURIComponent('Check out this CKAN success story: ' + storyUrl);
+
   document.getElementById('readerOverlay').classList.add('open');
   document.body.style.overflow = 'hidden';
   document.getElementById('readerPanel').scrollTop = 0;
@@ -125,6 +143,28 @@ function openReader(id) {
 function closeReader() {
   document.getElementById('readerOverlay').classList.remove('open');
   document.body.style.overflow = '';
+  history.replaceState(null, '', window.location.pathname);
+  document.getElementById('shareDropdown').classList.remove('open');
+}
+
+function youtubeEmbedUrl(url) {
+  var m = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|shorts\/))([A-Za-z0-9_-]{11})/);
+  return m ? 'https://www.youtube.com/embed/' + m[1] : url;
+}
+
+function toggleShare(e) {
+  e.stopPropagation();
+  document.getElementById('shareDropdown').classList.toggle('open');
+}
+
+function shareCopyLink() {
+  var url = getStoryUrl(STORIES[currentIdx].slug);
+  navigator.clipboard.writeText(url).then(function() {
+    var label = document.getElementById('shareCopyLabel');
+    label.textContent = '✓ Copied!';
+    setTimeout(function(){ label.textContent = 'Copy link'; }, 2000);
+  });
+  document.getElementById('shareDropdown').classList.remove('open');
 }
 
 function overlayBgClose(e) {
@@ -133,7 +173,7 @@ function overlayBgClose(e) {
 
 function navReader(dir) {
   var next = currentIdx + dir;
-  if (next >= 0 && next < STORIES.length) openReader(STORIES[next].id);
+  if (next >= 0 && next < STORIES.length) openReader(STORIES[next].slug);
 }
 
 function openNotify() {
@@ -186,4 +226,17 @@ document.addEventListener('keydown', function(e){
   if (e.key === 'Escape') { closeReader(); closeNotify(); }
 });
 
+document.addEventListener('click', function(e) {
+  var dd = document.getElementById('shareDropdown');
+  if (dd && dd.classList.contains('open') && !dd.contains(e.target) && e.target.id !== 'shareBtn') {
+    dd.classList.remove('open');
+  }
+});
+
 renderGrid('all');
+
+// Open story from URL param on page load
+(function() {
+  var slug = new URLSearchParams(window.location.search).get('story');
+  if (slug) openReader(slug);
+})();

--- a/ckanorg/static/scss/pages/_stories.scss
+++ b/ckanorg/static/scss/pages/_stories.scss
@@ -153,12 +153,43 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-se
     .reader-footer { padding: 20px 44px 32px; border-top: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
     .reader-submit-nudge { font-size: 13px; color: var(--muted); }
     .reader-submit-nudge a { color: var(--red); font-weight: 600; }
+    .reader-footer-right { display: flex; align-items: center; gap: 12px; }
     .reader-nav { display: flex; gap: 8px; }
     .reader-nav-btn { border: 1.5px solid var(--border); border-radius: 6px; padding: 8px 16px; font-size: 12px; font-weight: 600; cursor: pointer; background: #fff; font-family: inherit; transition: all 0.15s; }
     .reader-nav-btn:hover { border-color: #aaa; }
     .reader-nav-btn.primary { background: var(--red); border-color: var(--red); color: white; }
     .reader-nav-btn.primary:hover { background: var(--red-dark); }
     .reader-nav-btn:disabled { opacity: 0.3; cursor: default; pointer-events: none; }
+    .share-wrap { position: relative; }
+    .btn-share { display: inline-flex; align-items: center; gap: 7px; border: 1.5px solid var(--border); border-radius: 6px; padding: 8px 14px; font-size: 12px; font-weight: 600; cursor: pointer; background: #fff; font-family: inherit; transition: border-color 0.15s, background 0.15s; color: var(--text); }
+    .btn-share:hover { border-color: #bbb; background: var(--bg-soft); }
+    .share-btn-icon { width: 14px; height: 14px; flex-shrink: 0; color: var(--muted); }
+    .share-dropdown {
+        opacity: 0; pointer-events: none; transform: translateY(6px);
+        transition: opacity 0.15s, transform 0.15s;
+        position: absolute; bottom: calc(100% + 8px); right: 0;
+        background: #fff;
+        border: 1px solid rgba(0,0,0,0.09);
+        border-radius: 12px; padding: 5px;
+        min-width: 176px;
+        box-shadow: 0 8px 28px rgba(0,0,0,0.11), 0 2px 6px rgba(0,0,0,0.06);
+        z-index: 10;
+    }
+    .share-dropdown.open { opacity: 1; pointer-events: all; transform: translateY(0); }
+    .share-divider { height: 1px; background: var(--border); margin: 4px 8px; }
+    .share-option {
+        display: flex; align-items: center; gap: 10px;
+        width: 100%; text-align: left;
+        padding: 9px 11px; font-size: 13px; font-weight: 500;
+        border: none; background: none; cursor: pointer;
+        border-radius: 8px; font-family: inherit;
+        text-decoration: none; color: var(--text);
+        transition: background 0.12s;
+    }
+    .share-option:hover { background: var(--bg-soft); text-decoration: none; color: var(--text); }
+    .share-option-icon { width: 15px; height: 15px; flex-shrink: 0; color: var(--muted); }
+    .reader-video { margin: 28px 0 0; aspect-ratio: 16/9; border-radius: 10px; overflow: hidden; background: #000; }
+    .reader-video iframe { width: 100%; height: 100%; border: none; }
 
     /* ══ SUBMIT SECTION ══ */
     .submit-section { padding: 96px 48px; background: var(--bg-soft); border-top: 1px solid var(--border); }

--- a/ckanorg/templates/stories/stories.html
+++ b/ckanorg/templates/stories/stories.html
@@ -83,9 +83,40 @@
                 </div>
                 <div class="reader-footer">
                     <div class="reader-submit-nudge">{{ _('Have a story like this?') }} <a href="#submit" onclick="closeReader()">{{ _('Share it') }}</a></div>
-                    <div class="reader-nav">
-                        <button class="reader-nav-btn" id="rPrev" onclick="navReader(-1)">&#8592; {{ _('Prev') }}</button>
-                        <button class="reader-nav-btn primary" id="rNext" onclick="navReader(1)">{{ _('Next') }} &#8594;</button>
+                    <div class="reader-footer-right">
+                        <div class="share-wrap">
+                            <button class="btn-share" id="shareBtn" onclick="toggleShare(event)" aria-label="{{ _('Share this story') }}">
+                                <svg class="share-btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+                                {{ _('Share') }}
+                            </button>
+                            <div class="share-dropdown" id="shareDropdown">
+                                <button class="share-option" id="shareCopyBtn" onclick="shareCopyLink()">
+                                    <svg class="share-option-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>
+                                    <span id="shareCopyLabel">{{ _('Copy link') }}</span>
+                                </button>
+                                <div class="share-divider"></div>
+                                <a class="share-option" id="shareLinkedIn" href="#" target="_blank" rel="noopener">
+                                    <svg class="share-option-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M16 8a6 6 0 016 6v7h-4v-7a2 2 0 00-2-2 2 2 0 00-2 2v7h-4v-7a6 6 0 016-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>
+                                    <span>{{ _('LinkedIn') }}</span>
+                                </a>
+                                <a class="share-option" id="shareX" href="#" target="_blank" rel="noopener">
+                                    <svg class="share-option-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+                                    <span>{{ _('X') }}</span>
+                                </a>
+                                <a class="share-option" id="shareBluesky" href="#" target="_blank" rel="noopener">
+                                    <svg class="share-option-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.815 2.736 3.713 3.66 6.383 3.364.136-.02.275-.039.415-.056-.138.022-.276.04-.415.056-3.912.58-7.387 2.005-2.83 7.078 5.013 5.19 6.87-1.113 7.823-4.308.953 3.195 2.05 9.271 7.733 4.308 4.267-4.308 1.172-6.498-2.74-7.078a8.741 8.741 0 01-.415-.056c.14.017.279.036.415.056 2.67.297 5.568-.628 6.383-3.364.246-.828.624-5.79.624-6.478 0-.69-.139-1.861-.902-2.204-.659-.299-1.664-.62-4.3 1.24C16.046 4.748 13.087 8.687 12 10.8z"/></svg>
+                                    <span>{{ _('Bluesky') }}</span>
+                                </a>
+                                <a class="share-option" id="shareEmail" href="#">
+                                    <svg class="share-option-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="M22 7l-10 7L2 7"/></svg>
+                                    <span>{{ _('Email') }}</span>
+                                </a>
+                            </div>
+                        </div>
+                        <div class="reader-nav">
+                            <button class="reader-nav-btn" id="rPrev" onclick="navReader(-1)">&#8592; {{ _('Prev') }}</button>
+                            <button class="reader-nav-btn primary" id="rNext" onclick="navReader(1)">{{ _('Next') }} &#8594;</button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/stories/models.py
+++ b/stories/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db import models
+from django.utils.text import slugify
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 
@@ -64,6 +65,7 @@ class StoriesPage(Page):
         for story in stories_qs:
             stories.append({
                 "id": story.id, # type: ignore
+                "slug": story.slug or str(story.id),
                 "org": story.org,
                 "region": story.region,
                 "title": story.title,
@@ -79,6 +81,7 @@ class StoriesPage(Page):
                 "quote": str(story.quote),
                 "quoteAuthor": story.quote_author,
                 "portal": story.portal,
+                "youtubeUrl": story.youtube_url or "",
             })
         context["stories"] = stories
         # Add reCAPTCHA site key to context
@@ -330,11 +333,24 @@ class StoryItem(ClusterableModel):
         blank=True,
         help_text=_("Quote author (quoteAuthor)")
     )
+    slug = models.SlugField(
+        max_length=255,
+        null=True,
+        blank=True,
+        unique=True,
+        help_text=_("URL identifier used in share links — auto-generated from org + title if left blank (slug)")
+    )
     portal = models.URLField(
         max_length=512,
         null=True,
         blank=True,
         help_text=_("Portal URL (portal)")
+    )
+    youtube_url = models.URLField(
+        max_length=512,
+        null=True,
+        blank=True,
+        help_text=_("YouTube video URL for the session recording — embedded at the end of the story (youtube_url)")
     )
     # Optionally, keep legacy fields for compatibility
     created = models.DateTimeField(
@@ -358,7 +374,9 @@ class StoryItem(ClusterableModel):
         FieldPanel("outcome"),
         FieldPanel("quote"),
         FieldPanel("quote_author"),
+        FieldPanel("slug"),
         FieldPanel("portal"),
+        FieldPanel("youtube_url"),
     ]
 
     settings_panels = [
@@ -374,6 +392,17 @@ class StoryItem(ClusterableModel):
         ordering = ["title"]
         verbose_name = _("Story Item")
         verbose_name_plural = _("Story Items")
+
+    def save(self, *args, **kwargs):
+        if not self.slug:
+            base = slugify(f"{self.org or ''}-{self.title or ''}").strip('-') or 'story'
+            slug = base
+            counter = 1
+            while StoryItem.objects.filter(slug=slug).exclude(pk=self.pk).exists():
+                slug = f"{base}-{counter}"
+                counter += 1
+            self.slug = slug
+        super().save(*args, **kwargs)
 
     def __str__(self):
         return self.title or _("Untitled Story")


### PR DESCRIPTION
## Summary

- Redesigns the share button in the story reader with proper SVG icons (Copy link, LinkedIn, X, Bluesky, Email) — no emojis, animated dropdown with fade + slide-up
- Adds a `slug` field to `StoryItem` (auto-generated from org + title on save); share links now use `?story=city-of-toronto` instead of `?story=8` — human-readable and stable
- Adds an optional `youtube_url` field to `StoryItem`; embedded at the end of the reader when set
- URL updates to `?story=<slug>` when the reader opens and clears on close, enabling deep-linkable story URLs

Part of #338

## Test plan

- [ ] Open a story — URL bar should update to `?story=<org-title-slug>`
- [ ] Close reader — URL should return to `/success-stories/`
- [ ] Paste a `?story=<slug>` URL directly — reader should open on that story
- [ ] Share button opens dropdown with 5 options: Copy link, LinkedIn, X, Bluesky, Email
- [ ] Copy link copies the correct `?story=<slug>` URL and shows "✓ Copied!"
- [ ] LinkedIn / X / Bluesky / Email links open with correct URL and text pre-filled
- [ ] Add a YouTube URL to a story item in admin — video should embed at end of reader
- [ ] Leave slug blank when saving a story — slug should auto-generate from org + title
- [ ] Run `makemigrations stories` and `migrate` on the server after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)