### PR TITLE
feat(stories): add story submission form and Wagtail admin

### DIFF
--- a/ckanorg/static/css/main.css
+++ b/ckanorg/static/css/main.css
@@ -5397,6 +5397,153 @@ body {
   text-align: center;
   padding: 16px 0;
 }
+.stories-content .story-form-card {
+  background: #fff;
+  border: 1.5px solid var(--border);
+  border-radius: 16px;
+  padding: 24px 28px;
+  margin-top: 28px;
+}
+.stories-content .story-form-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  margin-bottom: 20px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--border);
+}
+.stories-content .story-form-icon {
+  width: 38px;
+  height: 38px;
+  background: var(--bg-soft);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--muted);
+}
+.stories-content .story-form-icon svg {
+  width: 16px;
+  height: 16px;
+}
+.stories-content .story-form-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 3px;
+}
+.stories-content .story-form-sub {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+.stories-content .sf-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.stories-content .sf-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-bottom: 12px;
+}
+.stories-content .sf-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.stories-content .sf-required {
+  color: var(--red);
+  font-size: 12px;
+}
+.stories-content .sf-optional {
+  font-weight: 400;
+  color: #bbb;
+  font-size: 11px;
+}
+.stories-content .sf-input {
+  background: var(--bg-soft);
+  border: 1.5px solid transparent;
+  border-radius: 8px;
+  padding: 10px 13px;
+  color: var(--text);
+  font-size: 13px;
+  font-family: inherit;
+  width: 100%;
+  transition: border-color 0.2s, background 0.2s;
+  box-sizing: border-box;
+}
+.stories-content .sf-input:focus {
+  outline: none;
+  border-color: var(--red);
+  background: #fff;
+}
+.stories-content .sf-input::placeholder {
+  color: #bbb;
+}
+.stories-content .sf-textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+.stories-content .sf-submit {
+  width: 100%;
+  margin-top: 6px;
+  background: var(--red);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  padding: 13px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.2s, transform 0.1s;
+  letter-spacing: 0.01em;
+}
+.stories-content .sf-submit:hover {
+  background: var(--red-dark);
+}
+.stories-content .sf-submit:active {
+  transform: scale(0.99);
+}
+.stories-content .sf-privacy {
+  font-size: 11px;
+  color: #bbb;
+  text-align: center;
+  margin-top: 10px;
+}
+.stories-content .sf-success {
+  text-align: center;
+  padding: 28px 0;
+}
+.stories-content .sf-success-icon {
+  width: 48px;
+  height: 48px;
+  background: #f0faf4;
+  border-radius: 50%;
+  margin: 0 auto 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  color: #16a34a;
+  font-weight: 700;
+}
+.stories-content .sf-success-title {
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--text);
+  margin-bottom: 6px;
+}
+.stories-content .sf-success-sub {
+  font-size: 13px;
+  color: var(--muted);
+}
 .stories-content .notify-success .big {
   font-size: 48px;
   margin-bottom: 14px;
@@ -5451,6 +5598,9 @@ body {
   .stories-content .submit-inner {
     grid-template-columns: 1fr;
     gap: 40px;
+  }
+  .stories-content .sf-row {
+    grid-template-columns: 1fr;
   }
   .stories-content .impact-row {
     gap: 8px;
@@ -10660,4 +10810,4 @@ img.linkdigital-logo {
   border: 1px solid #AAAAAA;
   border-radius: 4px;
   padding: 0 8px;
-}/*# sourceMappingURL=main.css.map */
+}

--- a/ckanorg/static/js/stories.js
+++ b/ckanorg/static/js/stories.js
@@ -186,4 +186,24 @@ document.addEventListener('keydown', function(e){
   if (e.key === 'Escape') { closeReader(); closeNotify(); }
 });
 
+async function submitStoryForm() {
+  var email = (document.getElementById('sfEmail').value || '').trim();
+  if (!email) { document.getElementById('sfEmail').focus(); return; }
+  var payload = {
+    name: (document.getElementById('sfName').value || '').trim(),
+    org: (document.getElementById('sfOrg').value || '').trim(),
+    email: email,
+    portal_url: (document.getElementById('sfPortal').value || '').trim(),
+    message: (document.getElementById('sfMessage').value || '').trim(),
+  };
+  var res = await fetch('/success-stories/submit/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCookie('csrftoken') },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) return;
+  document.getElementById('submitFormFields').style.display = 'none';
+  document.getElementById('submitFormSuccess').style.display = 'block';
+}
+
 renderGrid('all');

--- a/ckanorg/static/scss/pages/_stories.scss
+++ b/ckanorg/static/scss/pages/_stories.scss
@@ -209,6 +209,29 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-se
     .notify-submit:hover { background: var(--red-dark); }
     .notify-note { font-size: 11px; color: #bbb; text-align: center; }
     .notify-success { display: none; text-align: center; padding: 16px 0; }
+    .story-form-card { background: #fff; border: 1.5px solid var(--border); border-radius: 16px; padding: 24px 28px; margin-top: 28px; }
+    .story-form-header { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 20px; padding-bottom: 20px; border-bottom: 1px solid var(--border); }
+    .story-form-icon { width: 38px; height: 38px; background: var(--bg-soft); border-radius: 10px; display: flex; align-items: center; justify-content: center; flex-shrink: 0; color: var(--muted); }
+    .story-form-icon svg { width: 16px; height: 16px; }
+    .story-form-title { font-size: 14px; font-weight: 700; color: var(--text); margin-bottom: 3px; }
+    .story-form-sub { font-size: 12px; color: var(--muted); line-height: 1.5; }
+    .sf-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .sf-field { display: flex; flex-direction: column; gap: 5px; margin-bottom: 12px; }
+    .sf-label { font-size: 12px; font-weight: 600; color: var(--text); display: flex; align-items: center; gap: 5px; }
+    .sf-required { color: var(--red); font-size: 12px; }
+    .sf-optional { font-weight: 400; color: #bbb; font-size: 11px; }
+    .sf-input { background: var(--bg-soft); border: 1.5px solid transparent; border-radius: 8px; padding: 10px 13px; color: var(--text); font-size: 13px; font-family: inherit; width: 100%; transition: border-color 0.2s, background 0.2s; box-sizing: border-box; }
+    .sf-input:focus { outline: none; border-color: var(--red); background: #fff; }
+    .sf-input::placeholder { color: #bbb; }
+    .sf-textarea { resize: vertical; min-height: 80px; }
+    .sf-submit { width: 100%; margin-top: 6px; background: var(--red); color: white; border: none; border-radius: 8px; padding: 13px; font-size: 14px; font-weight: 700; cursor: pointer; font-family: inherit; transition: background 0.2s, transform 0.1s; letter-spacing: 0.01em; }
+    .sf-submit:hover { background: var(--red-dark); }
+    .sf-submit:active { transform: scale(0.99); }
+    .sf-privacy { font-size: 11px; color: #bbb; text-align: center; margin-top: 10px; }
+    .sf-success { text-align: center; padding: 28px 0; }
+    .sf-success-icon { width: 48px; height: 48px; background: #f0faf4; border-radius: 50%; margin: 0 auto 14px; display: flex; align-items: center; justify-content: center; font-size: 22px; color: #16a34a; font-weight: 700; }
+    .sf-success-title { font-size: 18px; font-weight: 800; color: var(--text); margin-bottom: 6px; }
+    .sf-success-sub { font-size: 13px; color: var(--muted); }
     .notify-success .big { font-size: 48px; margin-bottom: 14px; }
     .notify-success h3 { font-size: 20px; font-weight: 900; margin-bottom: 8px; }
     .notify-success p { font-size: 14px; color: var(--muted); text-align: center; }
@@ -228,6 +251,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-se
         .stories-grid { grid-template-columns: 1fr; gap: 16px; }
         .submit-section { padding: 56px 20px; }
         .submit-inner { grid-template-columns: 1fr; gap: 40px; }
+        .sf-row { grid-template-columns: 1fr; }
         .impact-row { gap: 8px; }
         .reader-body { padding: 0 24px 28px; }
         .reader-band { padding: 20px 24px; }

--- a/ckanorg/templates/stories/stories.html
+++ b/ckanorg/templates/stories/stories.html
@@ -152,6 +152,48 @@
                         <div style="font-size:13px; font-weight:700; margin-bottom:6px;">{{ _("Questions?") }}</div>
                         <div style="font-size:13px; color:var(--muted); line-height:1.65;">{{ _("Reach us at") }} <a href="mailto:comms&#64;ckan.org">comms&#64;ckan.org</a>. {{ _("We're happy to help shape your story if you're not sure where to start.") }}</div>
                     </div>
+                    <div class="story-form-card" id="storySubmitForm">
+                        <div class="story-form-header">
+                            <div class="story-form-icon">
+                                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+                            </div>
+                            <div>
+                                <div class="story-form-title">{{ _("Drop us a quick note") }}</div>
+                                <div class="story-form-sub">{{ _("Not ready for the full template? Leave your details and we'll reach out.") }}</div>
+                            </div>
+                        </div>
+                        <div id="submitFormFields">
+                            <div class="sf-row">
+                                <div class="sf-field">
+                                    <label class="sf-label" for="sfName">{{ _("Your name") }}</label>
+                                    <input class="sf-input" type="text" id="sfName" placeholder="Jane Smith" autocomplete="name" />
+                                </div>
+                                <div class="sf-field">
+                                    <label class="sf-label" for="sfOrg">{{ _("Organisation") }}</label>
+                                    <input class="sf-input" type="text" id="sfOrg" placeholder="City of Copenhagen" autocomplete="organization" />
+                                </div>
+                            </div>
+                            <div class="sf-field">
+                                <label class="sf-label" for="sfEmail">{{ _("Email") }} <span class="sf-required">*</span></label>
+                                <input class="sf-input" type="email" id="sfEmail" placeholder="you@yourorg.gov" required autocomplete="email" />
+                            </div>
+                            <div class="sf-field">
+                                <label class="sf-label" for="sfPortal">{{ _("Portal URL") }} <span class="sf-optional">{{ _("optional") }}</span></label>
+                                <input class="sf-input" type="url" id="sfPortal" placeholder="https://data.yourorg.gov" autocomplete="url" />
+                            </div>
+                            <div class="sf-field">
+                                <label class="sf-label" for="sfMessage">{{ _("Tell us about your portal") }} <span class="sf-optional">{{ _("optional") }}</span></label>
+                                <textarea class="sf-input sf-textarea" id="sfMessage" placeholder="{{ _('What does your CKAN portal do, who uses it, or what impact have you seen?') }}" rows="3"></textarea>
+                            </div>
+                            <button class="sf-submit" onclick="submitStoryForm()">{{ _("Send us a note") }} &rarr;</button>
+                            <div class="sf-privacy">{{ _("We'll follow up by email — no spam, no newsletters.") }}</div>
+                        </div>
+                        <div class="sf-success" id="submitFormSuccess" style="display:none;">
+                            <div class="sf-success-icon">&#x2713;</div>
+                            <div class="sf-success-title">{{ _("Got it — thanks!") }}</div>
+                            <div class="sf-success-sub">{{ _("We'll review your note and be in touch soon.") }}</div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/stories/admin.py
+++ b/stories/admin.py
@@ -2,7 +2,7 @@ from wagtail.admin.ui.tables import BooleanColumn
 from wagtail.snippets.models import register_snippet
 from wagtail.snippets.views.snippets import SnippetViewSet, SnippetViewSetGroup
 
-from stories.models import StoriesNotificationEmail, StoryItem
+from stories.models import StoriesNotificationEmail, StoryItem, StorySubmission
 
 
 class StoryItemAdmin(SnippetViewSet):
@@ -51,9 +51,34 @@ class StoriesNotificationEmailAdmin(SnippetViewSet):
     search_fields: tuple[str, ...] = ("email",) # type: ignore
 
 
+class StorySubmissionAdmin(SnippetViewSet):
+    model = StorySubmission
+    menu_label = "Story Submissions"  # type: ignore
+    icon = "form"  # type: ignore
+    menu_order = 200  # type: ignore
+    list_display: tuple[str, ...] = (  # type: ignore
+        "name",
+        "org",
+        "email",
+        "portal_url",
+        "created",
+    )
+    list_export: tuple[str, ...] = (  # type: ignore
+        "name",
+        "org",
+        "email",
+        "portal_url",
+        "message",
+        "created",
+    )
+    ordering: str = "-created"
+    list_filter: tuple[str, ...] = ("created",)  # type: ignore
+    search_fields: tuple[str, ...] = ("name", "org", "email")  # type: ignore
+
+
 @register_snippet
 class StoriesGroup(SnippetViewSetGroup):
     menu_label = "Stories" # type: ignore
     icon = "folder-open-inverse"
     menu_order = 150
-    items = (StoryItemAdmin, StoriesNotificationEmailAdmin)
+    items = (StoryItemAdmin, StorySubmissionAdmin, StoriesNotificationEmailAdmin)

--- a/stories/models.py
+++ b/stories/models.py
@@ -379,6 +379,50 @@ class StoryItem(ClusterableModel):
         return self.title or _("Untitled Story")
 
 
+class StorySubmission(models.Model):
+    """A submission from the success stories page — stored for team follow-up."""
+    name = models.CharField(
+        verbose_name=_("Name"),
+        max_length=255,
+        blank=True,
+        help_text=_("Submitter's name")
+    )
+    org = models.CharField(
+        verbose_name=_("Organisation"),
+        max_length=255,
+        blank=True,
+        help_text=_("Organisation or portal name")
+    )
+    email = models.EmailField(
+        verbose_name=_("Email"),
+        max_length=254,
+        help_text=_("Contact email")
+    )
+    portal_url = models.URLField(
+        verbose_name=_("Portal URL"),
+        max_length=512,
+        blank=True,
+        help_text=_("URL of their CKAN portal")
+    )
+    message = models.TextField(
+        verbose_name=_("Message"),
+        blank=True,
+        help_text=_("Brief description of their story or any notes")
+    )
+    created = models.DateTimeField(
+        verbose_name=_("Submitted"),
+        auto_now_add=True,
+    )
+
+    class Meta:  # type: ignore
+        ordering = ["-created"]
+        verbose_name = _("Story Submission")
+        verbose_name_plural = _("Story Submissions")
+
+    def __str__(self):
+        return f"{self.name or self.email} — {self.org or 'unknown org'}"
+
+
 class StoriesNotificationEmail(models.Model):
     """Model representing an email submission from the Stories page."""
     email = models.EmailField(

--- a/stories/urls.py
+++ b/stories/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import subscribe_story_notifications
+from .views import subscribe_story_notifications, submit_story
 
 urlpatterns = [
     path("notify/subscribe/", subscribe_story_notifications, name="stories-notify-subscribe"),
+    path("submit/", submit_story, name="stories-submit"),
 ]

--- a/stories/views.py
+++ b/stories/views.py
@@ -1,11 +1,18 @@
 import json
 
+from django.conf import settings
+from django.core.mail import send_mail
 from django.core.validators import validate_email
 from django.core.exceptions import ValidationError
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST
 
-from .models import StoriesNotificationEmail
+from .models import StoriesNotificationEmail, StorySubmission
+
+STORY_SUBMISSION_RECIPIENTS = [
+    "comms@ckan.org",
+    "yoana.popova@datopian.com",
+]
 
 
 @require_POST
@@ -26,3 +33,56 @@ def subscribe_story_notifications(request):
 
     obj, created = StoriesNotificationEmail.objects.get_or_create(email=email)
     return JsonResponse({"ok": True, "created": created})
+
+
+@require_POST
+def submit_story(request):
+    try:
+        payload = json.loads(request.body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return JsonResponse({"ok": False, "error": "Invalid payload"}, status=400)
+
+    email = (payload.get("email") or "").strip().lower()
+    if not email:
+        return JsonResponse({"ok": False, "error": "Email is required"}, status=400)
+
+    try:
+        validate_email(email)
+    except ValidationError:
+        return JsonResponse({"ok": False, "error": "Invalid email"}, status=400)
+
+    name = (payload.get("name") or "").strip()
+    org = (payload.get("org") or "").strip()
+    portal_url = (payload.get("portal_url") or "").strip()
+    message = (payload.get("message") or "").strip()
+
+    submission = StorySubmission.objects.create(
+        name=name,
+        org=org,
+        email=email,
+        portal_url=portal_url,
+        message=message,
+    )
+
+    subject = f"New CKAN story submission — {org or name or email}"
+    body = (
+        f"A new story submission was received.\n\n"
+        f"Name:       {name or '—'}\n"
+        f"Org:        {org or '—'}\n"
+        f"Email:      {email}\n"
+        f"Portal URL: {portal_url or '—'}\n\n"
+        f"Message:\n{message or '—'}\n\n"
+        f"View in admin: https://ckan.org/admin/snippets/stories/storysubmission/edit/{submission.pk}/\n"
+    )
+    try:
+        send_mail(
+            subject=subject,
+            message=body,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=STORY_SUBMISSION_RECIPIENTS,
+            fail_silently=True,
+        )
+    except Exception:
+        pass
+
+    return JsonResponse({"ok": True})


### PR DESCRIPTION
## Summary

- Adds a `StorySubmission` model (name, org, email, portal URL, message) with Wagtail admin under the existing Stories group
- Adds `POST /success-stories/submit/` endpoint: validates email, saves to DB, sends email notification to `comms@ckan.org`
- Adds a "Drop us a quick note" form card on the success stories page — lightweight alternative to the full Google Docs template
- Form has field labels, realistic placeholders, required/optional indicators, and a success state on submit

## What's in this PR

**Backend**
- `stories/models.py` — `StorySubmission` model
- `stories/admin.py` — `StorySubmissionAdmin` added to Wagtail Stories group
- `stories/views.py` — `submit_story` view
- `stories/urls.py` — `/success-stories/submit/` route

**Frontend**
- `ckanorg/templates/stories/stories.html` — form card in the submit section right column
- `ckanorg/static/js/stories.js` — `submitStoryForm()` function
- `ckanorg/static/scss/pages/_stories.scss` — form card styles
- `ckanorg/static/css/main.css` — compiled CSS

## Test plan

- [ ] Submit the form with valid data → record appears in Wagtail admin under Stories → Story Submissions
- [ ] Submit with blank email → form stays open (browser validation)
- [ ] Submit with invalid email → 400 response, form stays open
- [ ] Confirm email notification is sent on valid submission
- [ ] Submit again after success state → success message persists (expected behaviour)
- [ ] Check mobile layout — name/org fields stack to single column at ≤768px

## Notes

- Requires a migration on deploy: `python manage.py migrate stories`
- Email recipients are hardcoded in `views.py` (`comms@ckan.org`, `yoana.popova@datopian.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)