### PR TITLE
fix: prevent button text from wrapping to multiple lines

### DIFF
--- a/scss/base/_buttons.scss
+++ b/scss/base/_buttons.scss
@@ -12,6 +12,7 @@
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
+  white-space: nowrap;
   @include animate(border color background);
   font-size: $btn-font-size;
   border-radius: $btn-border-radius;


### PR DESCRIPTION
## Summary

- Adds `white-space: nowrap` to the `.btn` class in `scss/base/_buttons.scss`
- Prevents labels like **"Schedule a meeting"** from wrapping to a second line inside the button

Fixes #342

## Test plan

- [ ] Check the **Speak with us** section on the community page — button label should be on one line
- [ ] Check the same section on CKAN-for pages
- [ ] Verify no other buttons across the site are negatively affected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)