### PR TITLE
Add CKAN Community Discussion Forum + refresh community section design

### DIFF
--- a/ckanorg/templates/snippets/contribute_help_block.html
+++ b/ckanorg/templates/snippets/contribute_help_block.html
@@ -91,7 +91,7 @@
       </p>
       <ul class="ck-links">
         <li>
-          <a href="https://app.gitter.im/#/room/#ckan_chat:gitter.im" target="_blank" rel="noopener">
+          <a href="https://gitter.im/ckan/chat" target="_blank" rel="noopener">
             {% translate "Chat with us on Gitter" %}
           </a>
         </li>
@@ -111,7 +111,7 @@
         and the <a href="https://docs.ckan.org/en/" target="_blank" rel="noopener">CKAN docs</a> cover most common questions.
         <a href="https://github.com/ckan/ckan/discussions" target="_blank" rel="noopener">GitHub Discussions</a>
         is the place for CKAN support requests, project sharing, and questions about CKAN.
-        <a href="https://app.gitter.im/#/room/#ckan_chat:gitter.im" target="_blank" rel="noopener">Gitter</a> is where developers talk in real time.
+        <a href="https://gitter.im/ckan/chat" target="_blank" rel="noopener">Gitter</a> is where developers talk in real time.
         For broader conversations &mdash; funding, events, portal operations, and community strategy &mdash; head to the
         <a href="https://discuss.okfn.org/c/ckan/35" target="_blank" rel="noopener">CKAN Community Forum</a>.
       </p>
@@ -122,7 +122,7 @@
       </p>
       <ul class="ck-links">
         <li>
-          <a href="https://app.gitter.im/#/room/#ckan_chat:gitter.im" target="_blank" rel="noopener">
+          <a href="https://gitter.im/ckan/chat" target="_blank" rel="noopener">
             {% translate "Chat with us on Gitter" %}
           </a>
         </li>

--- a/ckanorg/templates/snippets/contribute_help_block.html
+++ b/ckanorg/templates/snippets/contribute_help_block.html
@@ -1,110 +1,153 @@
 {% load static i18n %}
 
 <style>
-    .grey-card p a {
-        text-decoration: none;
-        font-size: 20px;
-    }
+  .ck-section { padding: 56px 0 24px; }
+  .ck-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 64px;
+  }
+  @media (max-width: 767px) {
+    .ck-grid { grid-template-columns: 1fr; gap: 48px; }
+  }
+  .ck-rule {
+    width: 28px;
+    height: 3px;
+    background: #ED5248;
+    margin-bottom: 22px;
+  }
+  .ck-col h3 {
+    font-size: 30px;
+    font-weight: 700;
+    color: #111;
+    line-height: 1.15;
+    margin: 0 0 22px;
+    letter-spacing: -0.3px;
+  }
+  .ck-col p {
+    font-size: 16px;
+    line-height: 1.75;
+    color: #555;
+    margin: 0 0 16px;
+  }
+  .ck-col p:last-of-type { margin-bottom: 0; }
+  .ck-links {
+    list-style: none;
+    margin: 28px 0 0;
+    padding: 20px 0 0;
+    border-top: 1px solid #E8E8E8;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+  .ck-links li a {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 7px 0;
+    font-size: 16px;
+    font-weight: 500;
+    color: #111;
+    text-decoration: none;
+    transition: color 0.12s;
+  }
+  .ck-links li a::before {
+    content: '→';
+    color: #ED5248;
+    font-size: 13px;
+    flex-shrink: 0;
+    transition: transform 0.12s;
+    display: inline-block;
+  }
+  .ck-links li a:hover { color: #ED5248; }
+  .ck-links li a:hover::before { transform: translateX(3px); }
+  .ck-featured a { font-weight: 600; color: #D63B32; }
+  .ck-featured a::before { color: #D63B32; }
+  .ck-featured a:hover { color: #B83029; }
+  .ck-new {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #ED5248;
+    background: rgba(237,82,72,0.1);
+    padding: 2px 6px;
+    border-radius: 3px;
+  }
 </style>
 
-<div class="container">
-    <div class="two-columns inner-indent">
-        <div class="two-columns-item flex">
-            <div class="grey-card">
-                <h3>{% translate "Want to get involved?" %}</h3>
-                <p>{% translate "We’re a distributed community of 240 contributors strong, from all corners of the world and all walks of life united in our desire to build the best data management system on the internet. Come aboard!" %}</p>
-                <p>
-                    If you love <a href="https://www.linkedin.com/feed/hashtag/?keywords=data&highlightedUpdateUrns=urn%3Ali%3Aactivity%3A6798393137502003200" target="_blank" rel="noopener">#data</a> 
-                    and <a href="https://www.linkedin.com/feed/hashtag/?keywords=python&highlightedUpdateUrns=urn%3Ali%3Aactivity%3A6798393137502003200" target="_blank" rel="noopener">#python</a> 
-                    then join one of the weekly <a href="https://github.com/ckan/ckan/wiki/Weekly-Developer-Meetings" target="_blank" rel="noopener">Dev Meetings</a>. These are open to anyone so 
-                    feel free to drop by and ask questions or just listen in. Maybe you can even help with issues marked as <a href="https://github.com/ckan/ckan/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+for+Contribution%22" target="_blank" rel="noopener">Good for Contribution</a> 
-                    or tackle some of the project's Rockstar Tickets listed on <a href="https://github.com/ckan/ckan/projects/4" target="_blank" rel="noopener" aria-label="Link to GitHub">GitHub</a>.
-                </p>
+<div class="container ck-section">
+  <div class="ck-grid">
 
-                <ul>
-                    <li>
-                        <a href="https://gitter.im/ckan/chat" target="_blank" rel="noopener" class="link">
-                            {% translate "Chat to us on Gitter" %}
-                            <svg width="14" height="20" viewBox="0 0 14 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <title>Gitter Chat</title>
-                                <desc>Gitter Chat icon</desc>
-                                <path d="M0 0H1.91947V12.6679H0V0ZM11.6699 3.07099H13.5893V12.6679H11.6699V3.07099ZM3.91557 3.07099H5.83489V20H3.91557V3.07099ZM7.75437 3.07099H9.67384V20H7.75437V3.07099Z" fill="#ED5248"/>
-                            </svg>
-                        </a>
-                    </li>
-
-                    <li>
-                        <a href="https://github.com/ckan/ckan/wiki/Weekly-Developer-Meetings" target="_blank" rel="noopener" class="link">
-                            {% translate "Join Dev Meetings" %}
-                        </a>
-                    </li>
-                </ul>
-            </div>
-        </div>
-
-        <div class="two-columns-item flex">
-            <div class="grey-card">
-                <h3>{% translate "Need help with CKAN?" %}</h3>
-                <p>
-                    If you’re stuck on anything, chances are the answers awaits you on Stackoverflow or in 
-                    <a class="black" href="/">the docs</a>. <a href="https://github.com/ckan/ckan/discussions" target="_blank" rel="noopener">GitHub Discussions</a> 
-                    is the place to connect with the community, share your projects and ask questions or support requests about CKAN.
-                </p>
-                <p>
-                    If you want to report a bug or an actual issue with the CKAN software or documentation, please 
-                    post it on the <a href="https://github.com/ckan/ckan/issues" target="_blank" rel="noopener">issue tracker</a>. 
-                    For security related issues please email <a href="mailto:security@ckan.org">security@ckan.org</a>.
-                </p>
-                <br>
-
-                <ul>
-                    <li>
-                        <a href="https://github.com/ckan/ckan/discussions" target="_blank" rel="noopener" class="link">
-                            {% translate "GitHub Discussions" %}
-                        </a>
-                    </li>
-
-                    <li>
-                        <a href="https://stackoverflow.com/questions/tagged/ckan" target="_blank" rel="noopener">
-                            {% translate "Check Stackoverflow" %}
-                            <svg width="16" height="20" viewBox="0 0 16 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M11.1568 12.8021L3.5 10.9451L3.87151 9.4137L11.5284 11.2707L11.1568 12.8021Z" fill="#ED5248"/>
-                                <path d="M11.6702 10.9702L4.6543 7.38517L5.37123 5.98181L12.3871 9.56699L11.6702 10.9702Z" fill="#ED5248"/>
-                                <path d="M12.7516 9.07241L6.81836 3.88851L7.85496 2.70203L13.7884 7.88558L12.7516 9.07223" fill="#ED5248"/>
-                                <path d="M14.3838 7.40399L9.95898 0.885143L11.2631 0L15.6877 6.5192L14.384 7.40417" fill="#ED5248"/>
-                                <path d="M11.0342 14.7175L3.16699 14.288L3.25286 12.7145L11.1201 13.144L11.0342 14.7175Z" fill="#ED5248"/>
-                                <path d="M12.6658 18.4241V11.8959H14.2402L14.2413 20H0L0.000352647 11.8892H1.57615V18.4241H12.6658Z" fill="#ED5248"/>
-                                <path d="M3.14551 15.2786H11.0779V16.8544H3.14551V15.2787V15.2786Z" fill="#ED5248"/>
-                            </svg>
-                        </a>
-                    </li>
-
-                    <li>
-                        <a href="https://github.com/ckan/ckan/issues" target="_blank" rel="noopener">
-                            {% translate "Create an issue on GitHub" %}
-                            <svg width="21" height="20" viewBox="0 0 21 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <g clip-path="url(#clip0)">
-                                    <path d="M10.7409 0C5.13181 0 0.588867 4.54294 0.588867 10.1521C0.588867 14.9231 3.86258 18.8828 8.27938 19.9991C8.2284 19.8721 8.20335 19.6941 8.20335 19.517V17.7907H6.93412C6.24897 17.7907 5.61392 17.4866 5.33485 16.9276C5.0048 16.3185 4.95382 15.3793 4.1166 14.7952C3.86258 14.5922 4.06563 14.3891 4.3447 14.4142C4.87779 14.5663 5.30893 14.9222 5.71501 15.4545C6.12109 15.9876 6.29908 16.1146 7.06027 16.1146C7.41537 16.1146 7.97352 16.0895 8.48156 16.0126C8.76063 15.3015 9.24275 14.6674 9.82681 14.3632C6.42609 13.9571 4.80176 12.2818 4.80176 9.99741C4.80176 9.00726 5.2329 8.06808 5.94397 7.25592C5.71588 6.46881 5.41088 4.84448 6.04593 4.2103C7.56917 4.2103 8.48242 5.20045 8.71052 5.4536C9.47171 5.19959 10.3098 5.04752 11.1721 5.04752C12.0603 5.04752 12.8724 5.19959 13.6336 5.4536C13.8617 5.19959 14.7758 4.2103 16.2982 4.2103C16.9073 4.81942 16.6283 6.46881 16.3742 7.25592C17.0853 8.04303 17.4914 9.00726 17.4914 9.99741C17.4914 12.2818 15.8921 13.9571 12.5173 14.3123C13.4565 14.7944 14.1166 16.1647 14.1166 17.1799V19.492C14.1166 19.568 14.0915 19.644 14.0915 19.7201C18.0504 18.3497 20.893 14.5939 20.893 10.1521C20.893 4.54294 16.3501 0 10.7409 0Z" fill="#ED5248"/>
-                                </g>
-                                <defs>
-                                    <clipPath id="clip0">
-                                        <rect width="20.3041" height="20" fill="white" transform="translate(0.588867)"/>
-                                    </clipPath>
-                                </defs>
-                            </svg>
-                        </a>
-                    </li>
-
-                    <li>
-                        <a href="https://gitter.im/ckan/chat" target="_blank" rel="noopener">
-                            {% translate "Chat to us on Gitter" %}
-                            <svg width="14" height="20" viewBox="0 0 14 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M0 0H1.91947V12.6679H0V0ZM11.6699 3.07099H13.5893V12.6679H11.6699V3.07099ZM3.91557 3.07099H5.83489V20H3.91557V3.07099ZM7.75437 3.07099H9.67384V20H7.75437V3.07099Z" fill="#ED5248"/>
-                            </svg>
-                        </a>
-                    </li>
-                </ul>
-            </div>
-        </div>
+    <div class="ck-col">
+      <div class="ck-rule"></div>
+      <h3>{% translate "Want to get involved?" %}</h3>
+      <p>{% translate "We're a distributed community of 240+ contributors strong, from all corners of the world and all walks of life, united in our desire to build the best open-source data management system in the world. Come aboard!" %}</p>
+      <p>
+        If you work with data or Python, the weekly <a href="https://github.com/ckan/ckan/wiki/Weekly-Developer-Meetings" target="_blank" rel="noopener">Dev Meetings</a>
+        are a great place to start &mdash; open to everyone, no experience required. Drop in to listen, ask questions, or find out where your skills are most useful. If you&rsquo;re ready to dig in, issues labelled
+        <a href="https://github.com/ckan/ckan/issues?q=is%3Aissue+is%3Aopen+label%3A%22Good+for+Contribution%22" target="_blank" rel="noopener">Good for Contribution</a>
+        are a reliable starting point, and the <a href="https://github.com/ckan/ckan/projects/4" target="_blank" rel="noopener">Rockstar Tickets</a> list higher-impact work for those who want a bigger challenge.
+      </p>
+      <ul class="ck-links">
+        <li>
+          <a href="https://gitter.im/ckan/chat" target="_blank" rel="noopener">
+            {% translate "Chat with us on Gitter" %}
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/ckan/ckan/wiki/Weekly-Developer-Meetings" target="_blank" rel="noopener">
+            {% translate "Join Dev Meetings" %}
+          </a>
+        </li>
+      </ul>
     </div>
+
+    <div class="ck-col">
+      <div class="ck-rule"></div>
+      <h3>{% translate "Need help with CKAN?" %}</h3>
+      <p>
+        <a href="https://stackoverflow.com/questions/tagged/ckan" target="_blank" rel="noopener">Stack Overflow</a>
+        and the <a href="https://docs.ckan.org/en/" target="_blank" rel="noopener">CKAN docs</a> cover most common questions.
+        <a href="https://github.com/ckan/ckan/discussions" target="_blank" rel="noopener">GitHub Discussions</a>
+        is the place for support requests, project sharing, and questions about CKAN.
+        <a href="https://gitter.im/ckan/chat" target="_blank" rel="noopener">Gitter</a> is where developers talk in real time.
+        For broader conversations &mdash; funding, events, portal operations, and community strategy &mdash; head to the
+        <a href="https://discuss.okfn.org/c/ckan/35" target="_blank" rel="noopener">CKAN Community Forum</a>.
+      </p>
+      <p>
+        Found a bug or a documentation error? Open an issue on the
+        <a href="https://github.com/ckan/ckan/issues" target="_blank" rel="noopener">issue tracker</a>.
+        For security vulnerabilities, email <a href="mailto:security@ckan.org">security@ckan.org</a> directly &mdash; do not post publicly.
+      </p>
+      <ul class="ck-links">
+        <li>
+          <a href="https://gitter.im/ckan/chat" target="_blank" rel="noopener">
+            {% translate "Chat with us on Gitter" %}
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/ckan/ckan/discussions" target="_blank" rel="noopener">
+            {% translate "GitHub Discussions" %}
+          </a>
+        </li>
+        <li class="ck-featured">
+          <a href="https://discuss.okfn.org/c/ckan/35" target="_blank" rel="noopener">
+            {% translate "CKAN Community Discussion Forum" %} <span class="ck-new">New</span>
+          </a>
+        </li>
+        <li>
+          <a href="https://stackoverflow.com/questions/tagged/ckan" target="_blank" rel="noopener">
+            {% translate "Check Stack Overflow" %}
+          </a>
+        </li>
+        <li>
+          <a href="https://github.com/ckan/ckan/issues" target="_blank" rel="noopener">
+            {% translate "Create an issue on GitHub" %}
+          </a>
+        </li>
+      </ul>
+    </div>
+
+  </div>
 </div>

--- a/ckanorg/templates/snippets/contribute_help_block.html
+++ b/ckanorg/templates/snippets/contribute_help_block.html
@@ -91,7 +91,7 @@
       </p>
       <ul class="ck-links">
         <li>
-          <a href="https://gitter.im/ckan/chat" target="_blank" rel="noopener">
+          <a href="https://app.gitter.im/#/room/#ckan_chat:gitter.im" target="_blank" rel="noopener">
             {% translate "Chat with us on Gitter" %}
           </a>
         </li>
@@ -110,8 +110,8 @@
         <a href="https://stackoverflow.com/questions/tagged/ckan" target="_blank" rel="noopener">Stack Overflow</a>
         and the <a href="https://docs.ckan.org/en/" target="_blank" rel="noopener">CKAN docs</a> cover most common questions.
         <a href="https://github.com/ckan/ckan/discussions" target="_blank" rel="noopener">GitHub Discussions</a>
-        is the place for support requests, project sharing, and questions about CKAN.
-        <a href="https://gitter.im/ckan/chat" target="_blank" rel="noopener">Gitter</a> is where developers talk in real time.
+        is the place for CKAN support requests, project sharing, and questions about CKAN.
+        <a href="https://app.gitter.im/#/room/#ckan_chat:gitter.im" target="_blank" rel="noopener">Gitter</a> is where developers talk in real time.
         For broader conversations &mdash; funding, events, portal operations, and community strategy &mdash; head to the
         <a href="https://discuss.okfn.org/c/ckan/35" target="_blank" rel="noopener">CKAN Community Forum</a>.
       </p>
@@ -122,7 +122,7 @@
       </p>
       <ul class="ck-links">
         <li>
-          <a href="https://gitter.im/ckan/chat" target="_blank" rel="noopener">
+          <a href="https://app.gitter.im/#/room/#ckan_chat:gitter.im" target="_blank" rel="noopener">
             {% translate "Chat with us on Gitter" %}
           </a>
         </li>


### PR DESCRIPTION
## Summary

Closes #348

Adds the [CKAN Community Discussion Forum](https://discuss.okfn.org/c/ckan/35) to the community page and refreshes the design and copy of both community sections.

## Changes

### Design
- Grey card layout replaced with an open two-column layout — no boxes, more breathing room
- Larger, bolder section headings (30px) with a small red accent line above each
- Clean arrow-prefix link list (\`→\`) replacing the previous mixed SVG icon list

### Want to get involved?
- Updated contributor count to 240+ and refined copy ("open-source data management system in the world")
- Removed LinkedIn hashtag links (#data, #python)
- Rewritten second paragraph: focuses on Dev Meetings, Good for Contribution issues, and Rockstar Tickets
- "Chat to us on Gitter" → "Chat with us on Gitter"

### Need help with CKAN?
- Fully rewritten body copy — clearer, more direct
- Added CKAN Community Discussion Forum in both body text and link list (highlighted as new)
- Fixed docs link: \`https://docs.ckan.org/en/\`
- "Stackoverflow" → "Stack Overflow" (correct capitalisation)
- "support requests" → "CKAN support requests"
- "Chat to us on Gitter" → "Chat with us on Gitter"
- Links reordered by logical use: Gitter → GitHub Discussions → CKAN Community Forum → Stack Overflow → GitHub Issues

## Test plan
- [ ] Visit \`/community\` and verify both sections render correctly
- [ ] Check all links open to the correct destination
- [ ] Verify responsive layout on mobile
- [ ] Confirm CKAN Community Discussion Forum link and "New" badge display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)