### PR TITLE
fix(anniversary): fix form — persist success state, remove MailChimp, add notification, rename anchor

### DIFF
--- a/anniversary/models.py
+++ b/anniversary/models.py
@@ -1,7 +1,10 @@
-from wagtail.models import Page
 from django.conf import settings
+from django.core.mail import send_mail
+
+from wagtail.models import Page
+
 from blog.models import BlogPostPage
-from contact.models import Email, MailChimpSettings, send_contact_info
+from contact.models import Email
 from .forms import GetInvolvedForm
 
 class AnniversaryPage(Page):
@@ -33,19 +36,20 @@ class AnniversaryPage(Page):
 					address=email,
 					message=message,
 				)
-				member_info = {
-					"email_address": email,
-					"status": "subscribed",
-					"merge_fields": {
-						"FNAME": name.split(" ")[0] if name else "",
-						"LNAME": name.split(" ")[-1] if name else "",
-						"FORM": "Get Involved Form",
-						"ORG": organization,
-						"CKANUSE": relation,
-						"MESSAGE": message,
-					}
-				}
-				send_contact_info(request, member_info)
+				body = (
+					f"Name: {name}\n"
+					f"Email: {email}\n"
+					f"Organization: {organization}\n"
+					f"Relationship to CKAN: {relation}\n\n"
+					f"Message:\n{message}"
+				)
+				send_mail(
+					subject=f"[CKAN 20th] New 'Get Involved' submission from {name}",
+					message=body,
+					from_email=settings.DEFAULT_FROM_EMAIL,
+					recipient_list=["comms@ckan.org", "yoana.popova@datopian.com"],
+					fail_silently=True,
+				)
 				context['success'] = True
 			else:
 				context['form_errors'] = form.errors
@@ -55,10 +59,6 @@ class AnniversaryPage(Page):
 		# Stories
 		last_year_posts = BlogPostPage.objects.filter(is_story=True)
 		context["stories"] = last_year_posts.order_by("story_publish_date")
-		# Mailchimp
-		mailchimp_settings = MailChimpSettings.for_request(request)
-		context["mailchimp_api_key"] = getattr(mailchimp_settings, "api_key", "")
-		context["mailchimp_audience_id"] = getattr(mailchimp_settings, "audience_id", "")
 		# Recaptcha
 		context['recaptcha_sitekey'] = settings.RECAPTCHA_PUBLIC_KEY
 		return context

--- a/anniversary/models.py
+++ b/anniversary/models.py
@@ -47,7 +47,7 @@ class AnniversaryPage(Page):
 					subject=f"[CKAN 20th] New 'Get Involved' submission from {name}",
 					message=body,
 					from_email=settings.DEFAULT_FROM_EMAIL,
-					recipient_list=["comms@ckan.org", "yoana.popova@datopian.com"],
+					recipient_list=["comms@ckan.org"],
 					fail_silently=True,
 				)
 				context['success'] = True

--- a/ckanorg/static/js/anniversary.js
+++ b/ckanorg/static/js/anniversary.js
@@ -84,7 +84,8 @@ joinForm.addEventListener('submit', function (event) {
     event.preventDefault();
     joinForm.style.display = 'none';
     document.getElementById('successMsg').style.display = 'block';
-    setTimeout(function() {
-        joinForm.submit()
-    }, 3000);
+    fetch(window.location.pathname, {
+        method: 'POST',
+        body: new FormData(joinForm),
+    }).catch(console.error);
 });

--- a/ckanorg/templates/anniversary/anniversary.html
+++ b/ckanorg/templates/anniversary/anniversary.html
@@ -27,7 +27,7 @@
             <h1>{{ _("Twenty years of powering<br>open data worldwide") }}</h1>
             <p class="hero-desc">{{ _("What started as a scrappy tool inspired by a Perl archive has become the world's leading open data infrastructure — powering governments, researchers, and NGOs on every continent.") }}</p>
             <div class="hero-actions">
-                <a href="#join" class="btn-primary">{{ _("Take part in the celebration") }}</a>
+                <a href="#anniversary-form" class="btn-primary">{{ _("Take part in the celebration") }}</a>
                 <a href="#stories" class="btn-outline">{{ _("Read our stories") }}</a>
             </div>
         </div>
@@ -279,7 +279,7 @@
                 <div class="stories-progress">Showing <strong id="publishedCount">1 published</strong> of 20 stories · All stories publishing throughout 2026</div>
                 <div style="display:flex;gap:10px;">
                     <a href="https://ckan.org/newsletter/subscription/" target="_blank" class="btn-outline">{{ _('Subscribe for updates') }}</a>
-                    <a href="#join" class="btn-primary" onclick="prefillStoryForm()">{{ _('Submit your story') }}</a>
+                    <a href="#anniversary-form" class="btn-primary" onclick="prefillStoryForm()">{{ _('Submit your story') }}</a>
                 </div>
             </div>
         </div>
@@ -307,7 +307,7 @@
         </div>
 
         <!-- ══ GET INVOLVED ══ -->
-        <div id="join" class="involve-section">
+        <div id="anniversary-form" class="involve-section">
             <div class="involve-inner">
                 <div class="involve-left">
                     <div class="section-label">{{ _('Get Involved') }}</div>


### PR DESCRIPTION
Fixes four broken behaviours on the anniversary 'Get Involved' form.

## What was broken

**1. Page reloaded after success** — JS showed success then called `joinForm.submit()` after 3s, causing a full page POST+reload that wiped the success message.

**2. 'Already subscribed' error on re-submit** — form was calling `send_contact_info` which adds people to MailChimp as subscribers. If their email was already in MailChimp, they saw 'The member X already exists in the subscription list'. Wrong for a 'Get Involved' form, and it blocked re-submissions.

**3. No email notification** — submissions landed in DB (Wagtail admin → Contacts → Emails) but no one was notified.

**4. Poor anchor** — `#join` is vague. Renamed to `#anniversary-form`.

## Changes

**`ckanorg/static/js/anniversary.js`** — replace `setTimeout(() => joinForm.submit(), 3000)` with a background `fetch()` POST; success message persists, no page reload

**`anniversary/models.py`** — remove `send_contact_info` (MailChimp); add `send_mail` to comms@ckan.org on every submission; re-submissions from the same email now work

**`ckanorg/templates/anniversary/anniversary.html`** — rename section `id` and both `href` references from `#join` to `#anniversary-form` (hero CTA + stories CTA); internal form element IDs unchanged

## Test plan
- [ ] Hero 'Take part' button and stories 'Submit your story' button both scroll to the form
- [ ] Fill + submit → success message stays, page does not reload
- [ ] Email notification arrives at comms@ckan.org with name, email, org, relationship, message
- [ ] Record visible in Wagtail admin → Contacts → Emails (filter: Get Involved Form)
- [ ] Same email can submit again — no error
- [ ] URL `/20-years-of-ckan#anniversary-form` scrolls to the form correctly

Fixes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)