### PR TITLE
feat: sync story notification subscribers to Mailchimp

### DIFF
--- a/contact/models.py
+++ b/contact/models.py
@@ -39,6 +39,11 @@ class MailChimpSettings(BaseSiteSetting):
         help_text=_("MailChimp list ID"),
         blank=True,
     )
+    stories_audience_id = models.CharField(
+        max_length=255,
+        help_text=_("Mailchimp audience ID for success story notification subscribers"),
+        blank=True,
+    )
 
     class Meta: # type: ignore
         verbose_name = "MailChimp settings"
@@ -47,6 +52,7 @@ class MailChimpSettings(BaseSiteSetting):
     panels = [
         FieldPanel("api_key"),
         FieldPanel("audience_id"),
+        FieldPanel("stories_audience_id"),
         HelpPanel(
             template="contact/mailchimp_info.html",
             heading="Important info",

--- a/stories/views.py
+++ b/stories/views.py
@@ -1,5 +1,8 @@
 import json
+import logging
 
+import mailchimp_marketing as MailchimpMarketing
+from mailchimp_marketing.api_client import ApiClientError
 from django.conf import settings
 from django.core.mail import send_mail
 from django.core.validators import validate_email
@@ -7,16 +10,41 @@ from django.core.exceptions import ValidationError
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST
 
+from contact.models import MailChimpSettings
 from .models import StoriesNotificationEmail, StoriesRecipientsEmail, StorySubmission
 
 STORY_SUBMISSION_RECIPIENTS = [
     "comms@ckan.org",
 ]
 
+logger = logging.getLogger(__name__)
+
+
 def get_story_submission_recipients():
     """Returns a list of email addresses to which story submissions should be sent."""
     recipients = StoriesRecipientsEmail.objects.values_list("email", flat=True)
     return list(recipients) if recipients else STORY_SUBMISSION_RECIPIENTS
+
+
+def _sync_to_mailchimp(request, email):
+    mc = MailChimpSettings.for_request(request)
+    api_key = mc.api_key
+    audience_id = mc.stories_audience_id
+
+    if not api_key or not audience_id:
+        logger.warning("Mailchimp stories audience not configured — skipping subscriber sync")
+        return
+
+    try:
+        client = MailchimpMarketing.Client()
+        client.set_config({"api_key": api_key, "server": api_key.split("-")[-1]})
+        client.lists.add_list_member(audience_id, {"email_address": email, "status": "subscribed"})
+    except ApiClientError as error:
+        if error.status_code == 400 and "is already a list member" in error.text:
+            return
+        logger.error("Mailchimp sync failed for %s: %s", email, error.text)
+    except Exception:
+        logger.exception("Mailchimp sync failed for %s", email)
 
 
 @require_POST
@@ -37,6 +65,7 @@ def subscribe_story_notifications(request):
         return JsonResponse({"ok": False, "error": "Invalid email"}, status=400)
 
     obj, created = StoriesNotificationEmail.objects.get_or_create(email=email)
+    _sync_to_mailchimp(request, email)
     return JsonResponse({"ok": True, "created": created})
 
 


### PR DESCRIPTION
Closes #356.

## What

When someone submits their email via the "Get notified of new stories" form on /success-stories, it is now synced to a Mailchimp audience in addition to being saved locally.

## How

- Adds `stories_audience_id` field to the existing `MailChimpSettings` Wagtail model (Settings > MailChimp settings in the admin)
- `_sync_to_mailchimp()` in `stories/views.py` reads the API key and stories audience ID from `MailChimpSettings` — no new env vars needed
- Uses the existing `mailchimp_marketing` client, consistent with the contact form integration
- Already-subscribed addresses are handled silently
- Any Mailchimp failure is logged server-side but does not affect the user-facing response
- If `stories_audience_id` is blank in the admin, the sync is skipped cleanly

## Configuration (one-time, after deploy)

1. Run `python manage.py migrate`
2. Wagtail admin: Settings > MailChimp settings > paste the Stories audience ID in the new "Stories audience ID" field

The API key is already configured there. Nothing else needed on the server.

## Sending notifications

Manual. When a new story goes live: log into Mailchimp, create a campaign to the Stories audience, write a short note with the story title and link, send.

## Test plan

- [ ] After deploy, run `python manage.py migrate` to add the `stories_audience_id` column
- [ ] In Wagtail admin, paste the Stories audience ID under Settings > Mail
- [ ] Submit a new email via the form — verify it appears in the Mailchimp audience
- [ ] Submit the same email again — verify no error (already subscribed han
- [ ] With `stories_audience_id` blank — verify form still works and a warning appears in logs