### PR TITLE
feat(privacy): add Privacy Policy page and footer legal bar

### DIFF
--- a/ckan_pages/models.py
+++ b/ckan_pages/models.py
@@ -638,6 +638,43 @@ class CkanForPage(MetadataPageMixin, Page):
         return context
 
 
+class PrivacyPolicyPage(MetadataPageMixin, Page):
+
+    parent_page_types = ["home.HomePage"]
+    subpage_types = []
+    max_count = 1
+
+    last_updated = models.DateField(
+        blank=True,
+        null=True,
+        help_text="Date the policy was last reviewed (shown in the page header)",
+    )
+
+    jurisdiction = models.CharField(
+        max_length=256,
+        blank=True,
+        null=False,
+        default="UK GDPR & EU GDPR",
+        help_text="Jurisdiction label shown in the page header",
+    )
+
+    keywords = models.CharField(max_length=512, blank=True, null=True)
+
+    promote_panels = [
+        MultiFieldPanel(COMMON_PANELS, heading="Common page configuration"),
+    ]
+
+    content_panels = Page.content_panels + [
+        FieldPanel("last_updated"),
+        FieldPanel("jurisdiction"),
+    ]
+
+    def get_context(self, request, *args, **kwargs):
+        context = super().get_context(request, *args, **kwargs)
+        context["recaptcha_sitekey"] = settings.RECAPTCHA_PUBLIC_KEY
+        return context
+
+
 class FeatureDetailPage(MetadataPageMixin, Page):
 
     parent_page_types = ["ckan_pages.FeaturesPage"]

--- a/ckanorg/static/css/main.css
+++ b/ckanorg/static/css/main.css
@@ -6808,6 +6808,45 @@ img.dpga-logo {
   }
 }
 
+.footer-legal {
+  margin-top: 32px;
+  padding-top: 20px;
+  border-top: 1px solid #ddd;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.footer-legal .footer-legal-links {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin: 0;
+}
+.footer-legal .footer-legal-links li {
+  margin: 0;
+}
+.footer-legal .footer-legal-links li:first-of-type {
+  margin-right: 0;
+}
+.footer-legal .footer-legal-links a {
+  font-size: 14px;
+  color: #555;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.footer-legal .footer-legal-links a:hover,
+.footer-legal .footer-legal-links a:focus {
+  color: #ED5248;
+  text-decoration: underline;
+}
+.footer-legal .footer-copyright {
+  margin: 0;
+  font-size: 13px;
+  color: #888;
+}
+
 .social-container {
   position: relative;
 }

--- a/ckanorg/static/css/privacy.css
+++ b/ckanorg/static/css/privacy.css
@@ -1,0 +1,395 @@
+/* ─────────────────────────────────────────────
+   Privacy Policy page styles
+   Scoped under .privacy so nothing leaks into the
+   rest of the site. Uses SF Pro Display (already
+   loaded by main.css) and CKAN red #ED5248.
+   ───────────────────────────────────────────── */
+
+.privacy {
+  --pp-red: #ed5248;
+  --pp-red-hover: #97342d;
+  --pp-red-light: #fef2f1;
+  --pp-ink: #18181b;
+  --pp-ink-2: #52525c;
+  --pp-ink-3: #a1a1aa;
+  --pp-rule: #e4e4e8;
+  --pp-bg-2: #f8f8fa;
+  --pp-max: 720px;
+
+  font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  color: var(--pp-ink);
+  line-height: 1.7;
+}
+
+.privacy *,
+.privacy *::before,
+.privacy *::after { box-sizing: border-box; }
+
+.privacy a {
+  color: var(--pp-red);
+  font-weight: 400;
+  text-decoration: none;
+  transition: color 0.3s ease-in-out;
+}
+
+.privacy a:hover,
+.privacy a:focus {
+  color: var(--pp-red-hover);
+  text-decoration: underline;
+}
+
+/* ── HERO ── */
+.privacy-hero {
+  background: var(--pp-bg-2);
+  border-bottom: 1px solid var(--pp-rule);
+  padding: 52px 24px 44px;
+}
+
+.privacy-hero-inner {
+  max-width: var(--pp-max);
+  margin: 0 auto;
+}
+
+.privacy-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--pp-red);
+  margin: 0 0 14px;
+}
+
+.privacy-title {
+  font-size: 38px;
+  font-weight: 700;
+  letter-spacing: -0.035em;
+  line-height: 1.08;
+  color: var(--pp-ink);
+  margin: 0 0 18px;
+  text-wrap: balance;
+}
+
+.privacy-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px 32px;
+  font-size: 13.5px;
+  color: var(--pp-ink-3);
+}
+
+.privacy-meta span {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.privacy-meta-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--pp-red);
+  flex-shrink: 0;
+}
+
+.privacy-meta-val {
+  color: var(--pp-ink-2);
+  font-weight: 500;
+}
+
+/* ── LAYOUT ── */
+.privacy-layout {
+  max-width: var(--pp-max);
+  margin: 0 auto;
+  padding: 52px 24px 96px;
+}
+
+/* ── TOC ── */
+.privacy-toc {
+  background: var(--pp-bg-2);
+  border: 1px solid var(--pp-rule);
+  border-left: 3px solid var(--pp-red);
+  border-radius: 0 8px 8px 0;
+  padding: 24px 28px 28px;
+  margin-bottom: 60px;
+}
+
+.privacy-toc-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--pp-ink-3);
+  margin: 0 0 16px;
+}
+
+.privacy-toc ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: pp-toc-counter;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 32px;
+}
+
+.privacy-toc li {
+  counter-increment: pp-toc-counter;
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+  font-size: 13.5px;
+}
+
+.privacy-toc li::before {
+  content: counter(pp-toc-counter, decimal-leading-zero);
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--pp-red);
+  font-variant-numeric: tabular-nums;
+  min-width: 18px;
+  flex-shrink: 0;
+}
+
+.privacy-toc a { transition: color 0.15s; }
+
+/* ── SECTION ── */
+.privacy-section {
+  margin-bottom: 52px;
+  scroll-margin-top: 24px;
+}
+
+.privacy-section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+  margin-bottom: 22px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--pp-rule);
+}
+
+.privacy-section-num {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--pp-red);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  flex-shrink: 0;
+}
+
+.privacy-section-title {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  color: var(--pp-ink);
+  margin: 0;
+  text-wrap: balance;
+}
+
+/* ── PROSE ── */
+.privacy-prose p,
+.privacy-prose-p {
+  font-size: 16px;
+  color: var(--pp-ink-2);
+  margin: 0 0 16px;
+  max-width: 68ch;
+}
+
+.privacy-prose p:last-child { margin-bottom: 0; }
+
+/* ── SUBSECTION ── */
+.privacy-subsection { margin-bottom: 28px; }
+
+.privacy-subsection-title {
+  font-size: 17px;
+  font-weight: 600;
+  color: var(--pp-ink);
+  margin: 0 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  letter-spacing: -0.01em;
+}
+
+.privacy-subsection-title::before {
+  content: '';
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: var(--pp-red);
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ── TABLE ── */
+.privacy-table-wrap {
+  overflow-x: auto;
+  margin: 0 0 20px;
+  border: 1px solid var(--pp-rule);
+  border-radius: 6px;
+}
+
+.privacy table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.privacy thead th {
+  background: var(--pp-bg-2);
+  padding: 10px 16px;
+  text-align: left;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--pp-ink-3);
+  border-bottom: 1px solid var(--pp-rule);
+  white-space: nowrap;
+}
+
+.privacy tbody td {
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--pp-rule);
+  color: var(--pp-ink-2);
+  vertical-align: top;
+  line-height: 1.5;
+}
+
+.privacy tbody tr:last-child td { border-bottom: none; }
+
+.privacy tbody td:first-child {
+  font-weight: 500;
+  color: var(--pp-ink);
+}
+
+/* ── RIGHTS GRID ── */
+.privacy-rights-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.privacy-right-card {
+  padding: 16px 18px;
+  background: var(--pp-bg-2);
+  border: 1px solid var(--pp-rule);
+  border-radius: 6px;
+}
+
+.privacy-right-card-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--pp-ink);
+  margin: 0 0 5px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.privacy-right-card-title::before {
+  content: '';
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: var(--pp-red);
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.privacy-right-card p {
+  font-size: 13px;
+  color: var(--pp-ink-2);
+  line-height: 1.5;
+  margin: 0;
+  max-width: none;
+}
+
+/* ── NOTE BOX ── */
+.privacy-note {
+  background: var(--pp-bg-2);
+  border: 1px solid var(--pp-rule);
+  border-left: 3px solid var(--pp-ink-3);
+  border-radius: 0 6px 6px 0;
+  padding: 16px 20px;
+  margin: 20px 0;
+  font-size: 13.5px;
+  color: var(--pp-ink-2);
+  line-height: 1.6;
+}
+
+.privacy-note strong { color: var(--pp-ink); }
+
+/* ── CONTACT CARD ── */
+.privacy-contact-card {
+  background: var(--pp-bg-2);
+  border: 1px solid var(--pp-rule);
+  border-radius: 10px;
+  padding: 36px 40px;
+  margin-top: 64px;
+}
+
+.privacy-contact-card h3 {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  color: var(--pp-ink);
+  margin: 0 0 10px;
+}
+
+.privacy-contact-card > p {
+  font-size: 15px;
+  color: var(--pp-ink-2);
+  margin: 0 0 28px;
+  max-width: 56ch;
+}
+
+.privacy-contact-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.privacy-contact-row {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  font-size: 14px;
+}
+
+.privacy-contact-row-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--pp-ink-3);
+  min-width: 90px;
+  padding-top: 2px;
+  flex-shrink: 0;
+}
+
+.privacy-contact-row-val {
+  color: var(--pp-ink-2);
+  line-height: 1.5;
+}
+
+.privacy-contact-divider {
+  height: 1px;
+  background: var(--pp-rule);
+  margin: 20px 0;
+}
+
+/* ── RESPONSIVE ── */
+@media (max-width: 600px) {
+  .privacy-title { font-size: 28px; }
+  .privacy-toc ol { grid-template-columns: 1fr; }
+  .privacy-rights-grid { grid-template-columns: 1fr; }
+  .privacy-contact-card { padding: 28px 24px; }
+  .privacy-contact-row { flex-direction: column; gap: 4px; }
+  .privacy-contact-row-label { min-width: auto; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .privacy a,
+  .privacy-toc a { transition: none; }
+}

--- a/ckanorg/templates/ckan_pages/privacy_policy_page.html
+++ b/ckanorg/templates/ckan_pages/privacy_policy_page.html
@@ -1,0 +1,419 @@
+{% extends "base.html" %}
+{% load static wagtailmetadata_tags %}
+
+{% block head %}
+    <meta name="description" content="{{ page.title }} — how ckan.org collects, uses and protects your personal data.">
+{% endblock head %}
+
+{% block meta_tags %}{% meta_tags %}{% endblock %}
+
+{% block main_css %}
+    {{ block.super }}
+    <link href="{% static 'css/privacy.css' %}" rel="stylesheet">
+{% endblock main_css %}
+
+{% block content %}
+<div class="privacy">
+
+  <!-- HERO -->
+  <section class="privacy-hero">
+    <div class="privacy-hero-inner">
+      <p class="privacy-eyebrow">Legal &amp; Compliance</p>
+      <h1 class="privacy-title">Privacy Policy</h1>
+      <div class="privacy-meta">
+        {% if page.last_updated %}
+        <span><span class="privacy-meta-dot"></span>Last updated: <span class="privacy-meta-val">{{ page.last_updated|date:"j F Y" }}</span></span>
+        {% endif %}
+        {% if page.jurisdiction %}
+        <span><span class="privacy-meta-dot"></span>Jurisdiction: <span class="privacy-meta-val">{{ page.jurisdiction }}</span></span>
+        {% endif %}
+      </div>
+    </div>
+  </section>
+
+  <!-- MAIN -->
+  <div class="privacy-layout">
+
+    <!-- TABLE OF CONTENTS -->
+    <nav class="privacy-toc" aria-label="Table of contents">
+      <p class="privacy-toc-label">Contents</p>
+      <ol>
+        <li><a href="#who-we-are">Who we are</a></li>
+        <li><a href="#data-we-collect">Data we collect</a></li>
+        <li><a href="#how-we-use-data">How we use your data</a></li>
+        <li><a href="#legal-basis">Legal basis</a></li>
+        <li><a href="#analytics-cookies">Analytics &amp; cookies</a></li>
+        <li><a href="#third-parties">Third-party services</a></li>
+        <li><a href="#data-retention">Data retention</a></li>
+        <li><a href="#your-rights">Your rights</a></li>
+        <li><a href="#international-transfers">International transfers</a></li>
+        <li><a href="#contact">Contact &amp; complaints</a></li>
+      </ol>
+    </nav>
+
+    <!-- 01 WHO WE ARE -->
+    <section class="privacy-section" id="who-we-are">
+      <div class="privacy-section-head">
+        <span class="privacy-section-num">01</span>
+        <h2 class="privacy-section-title">Who we are</h2>
+      </div>
+      <div class="privacy-prose">
+        <p>CKAN is an open-source data management system used by governments, research institutions, and organisations worldwide to publish and share data. The ckan.org website is the official home of the CKAN project.</p>
+        <p>CKAN assets — including its legal identity and trademarks — are held in trust by the <strong><a href="https://okfn.org/en/" target="_blank" rel="noopener">Open Knowledge Foundation (OKFN)</a></strong>, a non-profit organisation incorporated in England &amp; Wales as a private company limited by guarantee (company number 05133759). OKFN is the data controller for personal data collected through this website.</p>
+        <p><a href="https://www.datopian.com/" target="_blank" rel="noopener">Datopian</a> and <a href="https://linkdigital.com.au/" target="_blank" rel="noopener">Link Digital</a> serve as co-stewards of the CKAN project and contribute to the ongoing development and maintenance of ckan.org.</p>
+        <p>This privacy policy explains what personal data we collect when you use ckan.org, how we use it, and the rights available to you under the UK General Data Protection Regulation (UK GDPR) and, where applicable, the EU General Data Protection Regulation (EU GDPR).</p>
+      </div>
+    </section>
+
+    <!-- 02 DATA WE COLLECT -->
+    <section class="privacy-section" id="data-we-collect">
+      <div class="privacy-section-head">
+        <span class="privacy-section-num">02</span>
+        <h2 class="privacy-section-title">Data we collect</h2>
+      </div>
+      <div class="privacy-prose">
+        <p>We collect personal data in the following ways:</p>
+        <br>
+      </div>
+
+      <div class="privacy-subsection">
+        <p class="privacy-subsection-title">Newsletter subscriptions</p>
+        <p class="privacy-prose-p">When you subscribe to the CKAN newsletter via the form on our website, we collect your <strong>name</strong> and <strong>email address</strong>. This information is used solely to send you updates, news, and announcements about the CKAN project.</p>
+      </div>
+
+      <div class="privacy-subsection">
+        <p class="privacy-subsection-title">Contact and support forms</p>
+        <p class="privacy-prose-p">When you submit a contact or support enquiry, we collect your <strong>name</strong>, <strong>email address</strong>, and the <strong>content of your message</strong>. We use this to respond to your enquiry.</p>
+      </div>
+
+      <div class="privacy-subsection">
+        <p class="privacy-subsection-title">Story and content submissions</p>
+        <p class="privacy-prose-p">When you submit a success story or other content via the forms on ckan.org, we collect your <strong>name</strong>, <strong>email address</strong>, <strong>organisation</strong>, and the <strong>content of your submission</strong>. This is used to review and publish your submission, and to follow up with you if needed.</p>
+      </div>
+
+      <div class="privacy-subsection">
+        <p class="privacy-subsection-title">CKAN Monthly Live invitations</p>
+        <p class="privacy-prose-p">If you sign up to be invited to CKAN Monthly Live — our regular community sessions — we collect your <strong>name</strong> and <strong>email address</strong> to send you event invitations, session announcements, and reminders. You can unsubscribe at any time.</p>
+      </div>
+
+      <div class="privacy-subsection">
+        <p class="privacy-subsection-title">Server logs</p>
+        <p class="privacy-prose-p">Our web server automatically records standard technical information, including your <strong>IP address</strong>, browser type, operating system, referring URLs, and pages visited. This data is used for security monitoring and troubleshooting, and is not used to identify individuals.</p>
+      </div>
+
+      <div class="privacy-subsection">
+        <p class="privacy-subsection-title">Analytics data</p>
+        <p class="privacy-prose-p">We collect aggregated, anonymised information about how visitors use ckan.org. This does not include personally identifiable information. See <a href="#analytics-cookies">Section 5</a> for details.</p>
+      </div>
+    </section>
+
+    <!-- 03 HOW WE USE -->
+    <section class="privacy-section" id="how-we-use-data">
+      <div class="privacy-section-head">
+        <span class="privacy-section-num">03</span>
+        <h2 class="privacy-section-title">How we use your data</h2>
+      </div>
+
+      <div class="privacy-table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Purpose</th>
+              <th>Data used</th>
+              <th>Legal basis</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Send CKAN newsletter and updates</td>
+              <td>Name, email address</td>
+              <td>Consent</td>
+            </tr>
+            <tr>
+              <td>Respond to contact and support enquiries</td>
+              <td>Name, email, message content</td>
+              <td>Legitimate interests</td>
+            </tr>
+            <tr>
+              <td>Review and publish story and content submissions</td>
+              <td>Name, email, organisation, submission content</td>
+              <td>Legitimate interests</td>
+            </tr>
+            <tr>
+              <td>Send CKAN Monthly Live invitations and reminders</td>
+              <td>Name, email address</td>
+              <td>Consent</td>
+            </tr>
+            <tr>
+              <td>Security monitoring and troubleshooting</td>
+              <td>Server logs, IP address</td>
+              <td>Legitimate interests</td>
+            </tr>
+            <tr>
+              <td>Understand how the site is used</td>
+              <td>Anonymised analytics data</td>
+              <td>Legitimate interests</td>
+            </tr>
+            <tr>
+              <td>Comply with legal obligations</td>
+              <td>Any relevant data</td>
+              <td>Legal obligation</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="privacy-prose">
+        <p>We do not sell, rent, or share your personal data with third parties for their own marketing purposes.</p>
+      </div>
+    </section>
+
+    <!-- 04 LEGAL BASIS -->
+    <section class="privacy-section" id="legal-basis">
+      <div class="privacy-section-head">
+        <span class="privacy-section-num">04</span>
+        <h2 class="privacy-section-title">Legal basis for processing</h2>
+      </div>
+      <div class="privacy-prose">
+        <p>Under UK GDPR and EU GDPR, we rely on the following lawful bases:</p>
+        <p><strong>Consent</strong> — where you have actively chosen to receive communications (for example, by subscribing to our newsletter). You may withdraw consent at any time by using the unsubscribe link in any email we send, or by contacting us directly.</p>
+        <p><strong>Legitimate interests</strong> — where processing is necessary for our legitimate interests as a non-profit open-source project operator, and those interests are not overridden by your rights. This covers responding to enquiries, maintaining website security, and understanding how ckan.org is used.</p>
+        <p><strong>Legal obligation</strong> — where we are required to process data to comply with a legal requirement.</p>
+        <p><strong>Performance of a contract</strong> — where processing is necessary to fulfil obligations to registered users of the site.</p>
+      </div>
+    </section>
+
+    <!-- 05 ANALYTICS & COOKIES -->
+    <section class="privacy-section" id="analytics-cookies">
+      <div class="privacy-section-head">
+        <span class="privacy-section-num">05</span>
+        <h2 class="privacy-section-title">Analytics &amp; cookies</h2>
+      </div>
+
+      <div class="privacy-subsection">
+        <p class="privacy-subsection-title">Analytics</p>
+        <p class="privacy-prose-p">ckan.org uses <strong>Plausible Analytics</strong>, a privacy-friendly analytics tool that does not use cookies, does not collect personally identifiable information, and does not track visitors across websites. Plausible is compliant with GDPR, CCPA, and PECR. Aggregated usage data (such as page views and referral sources) helps us understand how the site is used and improve it.</p>
+      </div>
+
+      <div class="privacy-subsection">
+        <p class="privacy-subsection-title">Essential cookies</p>
+        <p class="privacy-prose-p">We use session cookies that are strictly necessary for the website to function — for example, to maintain a logged-in session for site administrators. These cookies are deleted when you close your browser and do not track you.</p>
+      </div>
+
+      <div class="privacy-subsection">
+        <p class="privacy-subsection-title">reCAPTCHA</p>
+        <p class="privacy-prose-p">Our contact and subscription forms use Google reCAPTCHA to protect against automated spam submissions. reCAPTCHA may set cookies and collect information about your device and interactions with the form. This processing is governed by <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Google's Privacy Policy</a>.</p>
+      </div>
+
+      <div class="privacy-note">
+        <strong>No cross-site tracking.</strong> We do not use advertising cookies, social media tracking pixels, or any third-party cookies that monitor your activity across other websites.
+      </div>
+    </section>
+
+    <!-- 06 THIRD PARTIES -->
+    <section class="privacy-section" id="third-parties">
+      <div class="privacy-section-head">
+        <span class="privacy-section-num">06</span>
+        <h2 class="privacy-section-title">Third-party services</h2>
+      </div>
+      <div class="privacy-prose">
+        <p>ckan.org integrates with the following third-party services. Each has its own privacy policy and data processing terms.</p>
+      </div>
+
+      <div class="privacy-table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Service</th>
+              <th>Purpose</th>
+              <th>Data shared</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Google reCAPTCHA</td>
+              <td>Spam protection on forms</td>
+              <td>Device &amp; interaction data</td>
+            </tr>
+            <tr>
+              <td>GitHub (ghbtns.com)</td>
+              <td>Display CKAN repository star count</td>
+              <td>Your IP address / browser headers</td>
+            </tr>
+            <tr>
+              <td>Plausible Analytics</td>
+              <td>Anonymised website analytics</td>
+              <td>No personal data</td>
+            </tr>
+            <tr>
+              <td>Mailchimp</td>
+              <td>Newsletter and CKAN Monthly Live email delivery</td>
+              <td>Name, email address</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="privacy-prose">
+        <p>We take reasonable steps to ensure that any third-party providers we use handle data in a manner consistent with applicable data protection law. Where data is processed on our behalf, we have data processing agreements in place as required.</p>
+      </div>
+    </section>
+
+    <!-- 07 DATA RETENTION -->
+    <section class="privacy-section" id="data-retention">
+      <div class="privacy-section-head">
+        <span class="privacy-section-num">07</span>
+        <h2 class="privacy-section-title">Data retention</h2>
+      </div>
+      <div class="privacy-prose">
+        <p>We retain personal data only for as long as necessary for the purpose it was collected, or as required by law.</p>
+      </div>
+
+      <div class="privacy-table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Data</th>
+              <th>Retention period</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Newsletter subscriber data</td>
+              <td>Until you unsubscribe or request deletion</td>
+            </tr>
+            <tr>
+              <td>Contact form submissions</td>
+              <td>Up to 2 years, or until the matter is resolved</td>
+            </tr>
+            <tr>
+              <td>Story and content submission data</td>
+              <td>Retained while the content is live; deleted on request</td>
+            </tr>
+            <tr>
+              <td>CKAN Monthly Live subscriber data</td>
+              <td>Until you unsubscribe or request deletion</td>
+            </tr>
+            <tr>
+              <td>Server logs</td>
+              <td>Up to 90 days</td>
+            </tr>
+            <tr>
+              <td>Analytics data</td>
+              <td>Aggregated and anonymised; retained indefinitely</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="privacy-prose">
+        <p>When data is no longer needed, it is securely deleted or anonymised.</p>
+      </div>
+    </section>
+
+    <!-- 08 YOUR RIGHTS -->
+    <section class="privacy-section" id="your-rights">
+      <div class="privacy-section-head">
+        <span class="privacy-section-num">08</span>
+        <h2 class="privacy-section-title">Your rights</h2>
+      </div>
+      <div class="privacy-prose">
+        <p>Under UK GDPR and EU GDPR, you have the following rights in relation to your personal data. You may exercise these rights by contacting us using the details in <a href="#contact">Section 10</a>. We will respond within one month.</p>
+      </div>
+
+      <div class="privacy-rights-grid">
+        <div class="privacy-right-card">
+          <p class="privacy-right-card-title">Right of access</p>
+          <p>Request a copy of the personal data we hold about you.</p>
+        </div>
+        <div class="privacy-right-card">
+          <p class="privacy-right-card-title">Right to rectification</p>
+          <p>Ask us to correct inaccurate or incomplete data.</p>
+        </div>
+        <div class="privacy-right-card">
+          <p class="privacy-right-card-title">Right to erasure</p>
+          <p>Request that we delete your personal data in certain circumstances ("right to be forgotten").</p>
+        </div>
+        <div class="privacy-right-card">
+          <p class="privacy-right-card-title">Right to restriction</p>
+          <p>Ask us to limit how we use your data while a complaint is resolved.</p>
+        </div>
+        <div class="privacy-right-card">
+          <p class="privacy-right-card-title">Right to portability</p>
+          <p>Receive your data in a structured, machine-readable format where technically feasible.</p>
+        </div>
+        <div class="privacy-right-card">
+          <p class="privacy-right-card-title">Right to object</p>
+          <p>Object to processing based on legitimate interests, including direct communications.</p>
+        </div>
+        <div class="privacy-right-card">
+          <p class="privacy-right-card-title">Right to withdraw consent</p>
+          <p>Where processing is based on consent, withdraw it at any time without affecting prior processing.</p>
+        </div>
+        <div class="privacy-right-card">
+          <p class="privacy-right-card-title">Right to lodge a complaint</p>
+          <p>Complain to a supervisory authority if you believe your rights have been infringed.</p>
+        </div>
+      </div>
+
+      <div class="privacy-note">
+        <strong>UK residents</strong> may lodge a complaint with the <strong>Information Commissioner's Office (ICO)</strong> at <a href="https://ico.org.uk" target="_blank" rel="noopener">ico.org.uk</a> or by calling 0303 123 1113. <strong>EU residents</strong> may contact the supervisory authority in their member state.
+      </div>
+    </section>
+
+    <!-- 09 INTERNATIONAL TRANSFERS -->
+    <section class="privacy-section" id="international-transfers">
+      <div class="privacy-section-head">
+        <span class="privacy-section-num">09</span>
+        <h2 class="privacy-section-title">International transfers</h2>
+      </div>
+      <div class="privacy-prose">
+        <p>As a global open-source project, some of the third-party services we use (such as Google reCAPTCHA) may process data outside the United Kingdom or the European Economic Area. Where this occurs, we ensure that appropriate safeguards are in place — such as Standard Contractual Clauses or adequacy decisions — as required by UK GDPR and EU GDPR.</p>
+        <p>Plausible Analytics is based in the European Union and processes all data within the EU, in compliance with GDPR.</p>
+      </div>
+    </section>
+
+    <!-- 10 CONTACT -->
+    <section class="privacy-section" id="contact">
+      <div class="privacy-section-head">
+        <span class="privacy-section-num">10</span>
+        <h2 class="privacy-section-title">Contact &amp; complaints</h2>
+      </div>
+      <div class="privacy-prose">
+        <p>If you have any questions about this privacy policy, wish to exercise your data rights, or have a concern about how your data is handled, please contact the data controller:</p>
+      </div>
+    </section>
+
+    <!-- CONTACT CARD -->
+    <div class="privacy-contact-card">
+      <h3>Open Knowledge Foundation</h3>
+      <p>Data controller for ckan.org — CKAN's assets and legal identity are held in trust by OKFN, a non-profit registered in England &amp; Wales.</p>
+
+      <div class="privacy-contact-rows">
+        <div class="privacy-contact-row">
+          <span class="privacy-contact-row-label">Email</span>
+          <span class="privacy-contact-row-val"><a href="mailto:admin@okfn.org">admin@okfn.org</a></span>
+        </div>
+        <div class="privacy-contact-row">
+          <span class="privacy-contact-row-label">Website</span>
+          <span class="privacy-contact-row-val"><a href="https://okfn.org" target="_blank" rel="noopener">okfn.org</a></span>
+        </div>
+        <div class="privacy-contact-row">
+          <span class="privacy-contact-row-label">Registered in</span>
+          <span class="privacy-contact-row-val">England &amp; Wales — company no. 05133759</span>
+        </div>
+      </div>
+
+      <div class="privacy-contact-divider"></div>
+
+      <div class="privacy-contact-rows">
+        <div class="privacy-contact-row">
+          <span class="privacy-contact-row-label">ICO</span>
+          <span class="privacy-contact-row-val">UK residents may contact the Information Commissioner's Office: <a href="https://ico.org.uk" target="_blank" rel="noopener">ico.org.uk</a> — 0303 123 1113</span>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+{% endblock content %}

--- a/ckanorg/templates/footer.html
+++ b/ckanorg/templates/footer.html
@@ -1,6 +1,6 @@
 {% load static modal_tags page_tags i18n%}
 
-{% load wagtailsettings_tags %}
+{% load wagtailsettings_tags wagtailcore_tags %}
 {% get_settings %}
 
 <footer class="footer">
@@ -22,7 +22,7 @@
             
             <div class="two-columns-item social-container">
                 <span>{% translate "Sign up for our newsletter" %}</span>
-                <p>{% translate "Sign up to receive news and updates from CKAN. Your information will be used in accordance with our privacy policy. You may opt out at any time." %}</p>
+                <p>{% blocktranslate trimmed %}Sign up to receive news and updates from CKAN. Your information will be used in accordance with our{% endblocktranslate %} <a href="{% slugurl 'privacy-policy' %}">{% translate "privacy policy" %}</a>. {% blocktranslate trimmed %}You may opt out at any time.{% endblocktranslate %}</p>
                 <div class="footer-subscribe">
                     <form action="#" id="subscribe_form">
                         {% include "snippets/iframe.html" %}
@@ -94,6 +94,13 @@
                 <p>{% translate "Have questions or need support? Our team is ready to help you navigate and make the most of CKAN." %}</p>
                 {% form_modal %}
             </div>
+        </div>
+
+        <div class="footer-legal">
+            <ul class="footer-legal-links">
+                <li><a href="{% slugurl 'privacy-policy' %}">{% translate "Privacy Policy" %}</a></li>
+            </ul>
+            <p class="footer-copyright">{% blocktranslate trimmed %}CKAN assets are held in trust by Open Knowledge Foundation.{% endblocktranslate %}</p>
         </div>
     </div>
 </footer>

--- a/home/models.py
+++ b/home/models.py
@@ -83,6 +83,7 @@ class HomePage(WagtailCacheMixin, MetadataPageMixin, Page):
         'portals.OpenDataPortalPage',
         'anniversary.AnniversaryPage',
         'stories.StoriesPage',
+        'ckan_pages.PrivacyPolicyPage',
     ]
     max_count = 1
 

--- a/scss/layout/_footer.scss
+++ b/scss/layout/_footer.scss
@@ -39,3 +39,42 @@
     }
   }
 }
+
+.footer-legal {
+  margin-top: 32px;
+  padding-top: 20px;
+  border-top: 1px solid #ddd;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  .footer-legal-links {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    margin: 0;
+    li {
+      margin: 0;
+    }
+    li:first-of-type {
+      margin-right: 0;
+    }
+    a {
+      font-size: 14px;
+      color: #555;
+      text-decoration: none;
+      white-space: nowrap;
+      &:hover,
+      &:focus {
+        color: #ED5248;
+        text-decoration: underline;
+      }
+    }
+  }
+  .footer-copyright {
+    margin: 0;
+    font-size: 13px;
+    color: #888;
+  }
+}


### PR DESCRIPTION
Closes #358

## Summary

- Adds a `PrivacyPolicyPage` Wagtail model (child of `HomePage`, `max_count=1`) with two admin-editable fields: `last_updated` (DateField) and `jurisdiction` (CharField, default `"UK GDPR & EU GDPR"`), plus standard SEO promote panels
- Adds `privacy_policy_page.html` with all policy content: hero, table of contents, 10 numbered sections, a rights grid, third-party and retention tables, and a contact card — all scoped under `.privacy {}` to avoid leaking styles
- Adds `privacy.css` (page-scoped stylesheet, loaded only on this template via `{% block main_css %}`); force-added alongside existing `main.css` following the repo's convention for compiled static assets in `ckanorg/static/`
- Updates `footer.html` in three places:
  - Adds `wagtailcore_tags` to `{% load %}` (required for `slugurl`)
  - Links "privacy policy" in the newsletter copy using `{% slugurl 'privacy-policy' %}`
  - Adds a `.footer-legal` bar at the bottom of the footer with a Privacy Policy link and an OKFN copyright notice
- Adds `.footer-legal` SCSS block to `scss/layout/_footer.scss`
- Compiles `.footer-legal` rules into `ckanorg/static/css/main.css` (appended after existing footer rules, as no SCSS compiler is available locally)

**No migration files included** — migrations are gitignored and generated at deploy time from model definitions, consistent with repo convention.

## Policy content basis

The policy covers: data collected, legal basis (legitimate interest / consent), third-party services (Plausible Analytics, Mailchimp, reCAPTCHA, GitHub Pages), cookies, data retention, user rights under UK/EU GDPR, international transfers, and contact details for OKFN as data controller. Mailchimp confirmed as the mailing list provider from #357.

## Conflict check

No conflicts with any currently open PRs. Files changed in this PR:

| File | Open PRs touching this file |
|---|---|
| `ckan_pages/models.py` | none |
| `home/models.py` | none |
| `ckanorg/templates/footer.html` | none |
| `ckanorg/static/css/main.css` | none |
| `ckanorg/static/css/privacy.css` | new file |
| `ckanorg/templates/ckan_pages/privacy_policy_page.html` | new file |
| `scss/layout/_footer.scss` | none |

## Test plan

- [ ] Run `python manage.py migrate` — should create the `PrivacyPolicyPage` table without errors
- [ ] In Wagtail admin → Pages → Home, add a child page of type **Privacy Policy Page**; set slug to `privacy-policy`, fill in **Last updated** and **Jurisdiction**, publish
- [ ] Visit `/privacy-policy/` — page should render with correct hero meta, TOC, all 10 sections, rights grid, tables, and contact card
- [ ] Verify all links on the page use CKAN red (`#ED5248`) with no underline, and underline on hover
- [ ] In the site footer, verify "privacy policy" in the newsletter paragraph is a working link to `/privacy-policy/`
- [ ] In the site footer, verify the `.footer-legal` bar appears below the main content with a "Privacy Policy" link and the OKFN copyright line
- [ ] Resize to mobile (< 600px) — TOC should collapse to single column, rights grid to single column, contact card padding should reduce
- [ ] Confirm no visual regressions on other pages (styles are fully scoped to `.privacy {}`)